### PR TITLE
PKS T1 router name typo

### DIFF
--- a/sample_parameters/PAS_and_PKS/nsx_pipeline_config.yml
+++ b/sample_parameters/PAS_and_PKS/nsx_pipeline_config.yml
@@ -130,7 +130,7 @@ nsx_t_t1router_logical_switches_spec: |
       logical_switch_gw: 192.168.50.1 # Last octet should be 1 rather than 0
       subnet_mask: 24
 
-  - name: T1Router-PKS-Services
+  - name: T1-Router-PKS-Services
     switches:
     - name: PKS-Services
       logical_switch_gw: 192.168.60.1 # Last octet should be 1 rather than 0

--- a/sample_parameters/PKS_only/nsx_pipeline_config.yml
+++ b/sample_parameters/PKS_only/nsx_pipeline_config.yml
@@ -107,7 +107,7 @@ nsx_t_t1router_logical_switches_spec: |
       logical_switch_gw: 192.168.50.1 # Last octet should be 1 rather than 0
       subnet_mask: 24
 
-  - name: T1Router-PKS-Services
+  - name: T1-Router-PKS-Services
     switches:
     - name: PKS-Services
       logical_switch_gw: 192.168.60.1 # Last octet should be 1 rather than 0

--- a/sample_parameters/raw/pas_pks.yml
+++ b/sample_parameters/raw/pas_pks.yml
@@ -30,7 +30,7 @@ nsx_t_t1router_logical_switches_spec: |
       logical_switch_gw: 192.168.50.1 # Last octet should be 1 rather than 0
       subnet_mask: 24
 
-  - name: T1Router-PKS-Services
+  - name: T1-Router-PKS-Services
     switches:
     - name: PKS-Services
       logical_switch_gw: 192.168.60.1 # Last octet should be 1 rather than 0

--- a/sample_parameters/raw/pks.yml
+++ b/sample_parameters/raw/pks.yml
@@ -7,7 +7,7 @@ nsx_t_t1router_logical_switches_spec: |
       logical_switch_gw: 192.168.50.1 # Last octet should be 1 rather than 0
       subnet_mask: 24
 
-  - name: T1Router-PKS-Services
+  - name: T1-Router-PKS-Services
     switches:
     - name: PKS-Services
       logical_switch_gw: 192.168.60.1 # Last octet should be 1 rather than 0


### PR DESCRIPTION
`/s/T1Router-PKS-Services/T1-Router-PKS-Services/g`

To keep the router name consistent with the others

![image](https://user-images.githubusercontent.com/11538902/47508160-917a8600-d841-11e8-9279-d6f164fcc23a.png)
 

