### PR TITLE
improved docker related things

### DIFF
--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -13,4 +13,3 @@ RUN apt-get update && \
 ADD run.sh /home/run.sh
 
 ENTRYPOINT ["/home/run.sh"]
-

--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -13,3 +13,4 @@ RUN apt-get update && \
 ADD run.sh /home/run.sh
 
 ENTRYPOINT ["/home/run.sh"]
+

--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:17.10
-ADD run.sh /home/run.sh
 
 # https://docs.docker.com/compose/install/#install-compose
 RUN apt-get update && \
@@ -10,5 +9,7 @@ RUN apt-get update && \
     # download and install fly CLI
     wget -O /usr/local/bin/fly https://github.com/Concourse/Concourse/releases/download/v3.14.1/fly_linux_amd64 && \
     chmod +x /usr/local/bin/fly
+
+ADD run.sh /home/run.sh
 
 ENTRYPOINT ["/home/run.sh"]

--- a/docker_image/README.md
+++ b/docker_image/README.md
@@ -91,3 +91,4 @@ docker image save nsx-t-install:latest | bzip2 --best > nsx-t-install-release-`d
 ```
 wget -qO- https://github.com/maldex/nsx-t-datacenter-ci-pipelines/releases/download/20181101-1048/nsx-t-install-release-20181101-1048.tbz2 | bzip2 -d -c | docker load
 ```
+

--- a/docker_image/README.md
+++ b/docker_image/README.md
@@ -91,4 +91,3 @@ docker image save nsx-t-install:latest | bzip2 --best > nsx-t-install-release-`d
 ```
 wget -qO- https://github.com/maldex/nsx-t-datacenter-ci-pipelines/releases/download/20181101-1048/nsx-t-install-release-20181101-1048.tbz2 | bzip2 -d -c | docker load
 ```
-

--- a/docker_image/README.md
+++ b/docker_image/README.md
@@ -1,0 +1,93 @@
+# some general notes
+
+
+### install docker for ubuntu
+```
+sudo apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+sudo apt-get install -y docker-ce
+sudo systemctl status docker
+```
+
+
+### install docker for fedora/rh
+```
+function RH_get_variant_version(){   # returns [fc|el] [version]   (blanc between)
+    s=`uname -r | tr '.' '\n' | grep -e "^el" -e "^fc"`
+    echo "${s:0:2} ${s:2}"
+}
+function install_docker(){
+    read -r variant version <<< `RH_get_variant_version`
+    echo "  >> Installing X11 and Xfce for ${variant} ${version}"
+    case "${variant}" in
+    "el")
+        sudo wget -O /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/centos/docker-ce.repo
+        ;;
+    "fc")
+        sudo wget -O /etc/yum.repos.d/docker-ce.repo https://download.docker.com/linux/fedora/docker-ce.repo
+        ;;
+    *)
+        echo "ERROR: UNKNOWN OS '${variant} ${version}'"
+        return 99
+        ;;
+    esac
+
+    sudo yum install -y docker-ce
+ 
+    # local engine: enable and start
+    sudo systemctl enable docker; sudo systemctl start docker
+ 
+    # add all users that belong to users also to docker
+    for u in `getent group users | awk -F':' '{print $NF}' | tr ',' ' '`; do
+        sudo usermod -a -G docker ${u}
+    done 
+
+    sudo docker info
+    echo "done. don't forget to re-bash-yourself, group membership does not yet apply to this shell"
+}
+
+install_docker
+```
+
+
+# some notes about this container
+
+
+### build the container your own
+```
+cd ~
+git clone https://github.com/vmware/nsx-t-datacenter-ci-pipelines.git
+pushd ~/nsx-t-datacenter-ci-pipelines/docker_image
+docker build -t nsx-t-install .
+popd
+```
+
+
+### run the container
+(Assuming you have a nsx_pipeline_config.yml already prepared in /home/concourse)
+```
+docker run -it --name nsx-t-installer --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /home/concourse:/home/concourse \
+  nsx-t-install -CONCOURSE_URL http://192.168.18.146:8080 
+```
+
+
+### export this container
+```
+docker image save nsx-t-install:latest | bzip2 --best > nsx-t-install-release-`date +%Y%m%d-%H%M`.tbz2
+```
+
+
+### import this container
+```
+wget -qO- https://github.com/maldex/nsx-t-datacenter-ci-pipelines/releases/download/20181101-1048/nsx-t-install-release-20181101-1048.tbz2 | bzip2 -d -c | docker load
+```

--- a/docker_image/nsx-t-install-09122018.tar
+++ b/docker_image/nsx-t-install-09122018.tar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da41c3619d2219fba4c329d8d15e7d7f5c63b6d47be5021888b47e8b26e4b204
-size 460934144

--- a/docker_image/run.sh
+++ b/docker_image/run.sh
@@ -200,4 +200,3 @@ $stop_pipeline_cmd
 docker-compose down
 docker stop nsx-t-install-nginx
 exit 0
-

--- a/docker_image/run.sh
+++ b/docker_image/run.sh
@@ -200,3 +200,4 @@ $stop_pipeline_cmd
 docker-compose down
 docker stop nsx-t-install-nginx
 exit 0
+


### PR DESCRIPTION
Following up issue #18, this pr concerns a few docker-things:
- Dockerfile: moved `add run.sh` to bottom, don't redo the whole thing if only this script has changed.
- run.sh: added an argument parser for classic Unix-compatibily and not only relying on environment variables.
- run.sh: overwrite the `nsx_image_webserver` in the config.yml with altered concourse_url.
- run.sh: corrected fly initialization as described in #18 (login/sync sequence and adding `--non-interactive`)
- nsx-t-install-09122018.tar: removed, afaik can the _releases​ feature_ of your RCS be used for this.
- all: some other little tweaks. Feel free to test and improve.

thx
