### PR TITLE
Support for NSX-T 2.4.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-docker_image/nsx-t-install-03112019.tar filter=lfs diff=lfs merge=lfs -text
+docker_image/nsx-t-install-03132019.tar filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-docker_image/nsx-t-install-02222019.tar filter=lfs diff=lfs merge=lfs -text
-docker_image/nsx-t-install-03042019.tar filter=lfs diff=lfs merge=lfs -text
+docker_image/nsx-t-install-03112019.tar filter=lfs diff=lfs merge=lfs -text

--- a/docker_image/nsx-t-install-03042019.tar
+++ b/docker_image/nsx-t-install-03042019.tar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3fb3276c65a2feff68daceffaafdd98b8510938fd4e287d8c4da3d906335d0e8
-size 452814848

--- a/docker_image/nsx-t-install-03112019.tar
+++ b/docker_image/nsx-t-install-03112019.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca10a09648375033a94d0ba3ff769c9c1a83a3dd6935b41e5d79ca3ca461a4ec
+size 452813824

--- a/docker_image/nsx-t-install-03112019.tar
+++ b/docker_image/nsx-t-install-03112019.tar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ca10a09648375033a94d0ba3ff769c9c1a83a3dd6935b41e5d79ca3ca461a4ec
-size 452813824

--- a/docker_image/nsx-t-install-03132019.tar
+++ b/docker_image/nsx-t-install-03132019.tar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a5ae96e3105f8f1ffe2ac598c13f0bed69390c71fba1800b3abb6348f75782d
+size 458413056

--- a/docker_image/run.sh
+++ b/docker_image/run.sh
@@ -21,7 +21,7 @@ fi
 cd $BIND_MOUNT_DIR
 ova_file_name=$(ls -l *.ova | sed 's/.* nsx/nsx/;s/ova.*/ova/' | tail -n1)
 ovftool_file_name=$(ls -l *.bundle | sed 's/.* VMware-ovftool/VMware-ovftool/;s/bundle.*/bundle/' | tail -n1)
-nsxt_version=2.2.0
+nsxt_version=2.4.0
 if [[ $NSXT_VERSION != "" ]]; then
 	nsxt_version=$NSXT_VERSION
 fi

--- a/docker_image/run.sh
+++ b/docker_image/run.sh
@@ -50,15 +50,29 @@ if [[ $ova_file_name == "" ]] || [[ $ovftool_file_name == "" ]]; then
 	set +e
 fi
 
+unified_appliance=true
+version_num=$(echo $nsxt_version | cut -d'.' -f1)
+version_sub_num=$(echo $nsxt_version | cut -d'.' -f2)
+if [[ $version_num -le 2 ]] && [[ $version_sub_num -le 3 ]]; then
+    unified_appliance=false
+fi
+
 nsx_t_pipeline_branch=master
+nsxt_ansible_branch=v1.0.0
+
 if [[ $PIPELINE_BRANCH != "" ]]; then
 	nsx_t_pipeline_branch=$PIPELINE_BRANCH
+fi
+if [[ $unified_appliance ]]; then
+    nsxt_ansible_branch=master
 fi
 
 pipeline_internal_config="pipeline_config_internal.yml"
 echo "ovftool_file_name: $ovftool_file_name" > $pipeline_internal_config
 echo "ova_file_name: $ova_file_name" >> $pipeline_internal_config
+echo "unified_appliance: $unified_appliance" >> $pipeline_internal_config
 echo "nsx_t_pipeline_branch: $nsx_t_pipeline_branch" >> $pipeline_internal_config
+echo "nsxt_ansible_branch: $nsxt_ansible_branch" >> $pipeline_internal_config
 
 # start a web server to host static files such as ovftool and NSX manager OVA
 docker run --name nginx-server -v ${BIND_MOUNT_DIR}:/usr/share/nginx/html:ro -p ${IMAGE_WEBSERVER_PORT}:80 -d nginx

--- a/functions/create_hosts.sh
+++ b/functions/create_hosts.sh
@@ -161,6 +161,7 @@ tier0_uplink_next_hop_ip="$tier0_uplink_next_hop_ip_int"
 
 resource_reservation_off="$resource_reservation_off_int"
 nsx_manager_ssh_enabled="$nsx_manager_ssh_enabled_int"
+unified_appliance="$unified_appliance_int"
 EOF
 
   set_list_var_and_strip_whitespaces esx_available_vmnic_int hosts

--- a/functions/create_hosts.sh
+++ b/functions/create_hosts.sh
@@ -164,6 +164,12 @@ nsx_manager_ssh_enabled="$nsx_manager_ssh_enabled_int"
 unified_appliance="$unified_appliance_int"
 EOF
 
+  if [[ $unified_appliance_int == "true" ]]; then
+    echo "nsx_manager_role=nsx-manager nsx-controller" >> hosts
+  else
+    echo "nsx_manager_role=nsx-manager" >> hosts
+  fi
+
   set_list_var_and_strip_whitespaces esx_available_vmnic_int hosts
   set_list_var_and_strip_whitespaces clusters_to_install_nsx_int hosts
   set_list_var_and_strip_whitespaces per_cluster_vlans_int hosts

--- a/nsxt_yaml/basic_resources.yml
+++ b/nsxt_yaml/basic_resources.yml
@@ -72,6 +72,7 @@
 # Edge transport nodes, edge cluster
 ###############################################################################
     - name: Create transport node
+      # In 2.4.0 and later, transport nodes are already registered in basic_topology
       nsxt_transport_nodes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
@@ -107,6 +108,8 @@
         state: present
       with_items:
         - "{{groups['edge_nodes']}}"
+      when:
+        - hostvars['localhost'].unified_appliance == false
 
     - name: Define edge cluster members
       set_fact:
@@ -176,16 +179,16 @@
         - compute_manager_name: "{{compute_manager_name}}"
           cluster_name: "{{item}}"
         host_switch_spec:
-            resource_type: StandardHostSwitchSpec
-            host_switches:
-            - host_switch_profiles:
-              - name: "{{item}}-profile"
-                type: UplinkHostSwitchProfile
-              host_switch_name: "{{overlay_host_switch}}"
-              pnics: "{{pnic_list}}"
-              ip_assignment_spec:
-                resource_type: StaticIpPoolSpec
-                ip_pool_name: "{{vtep_ip_pool_name}}"
+          resource_type: StandardHostSwitchSpec
+          host_switches:
+          - host_switch_profiles:
+            - name: "{{item}}-profile"
+              type: UplinkHostSwitchProfile
+            host_switch_name: "{{overlay_host_switch}}"
+            pnics: "{{pnic_list}}"
+            ip_assignment_spec:
+              resource_type: StaticIpPoolSpec
+              ip_pool_name: "{{vtep_ip_pool_name}}"
         transport_zone_endpoints:
         - transport_zone_name: "{{overlay_transport_zone}}"
         state: present
@@ -211,14 +214,15 @@
         os_type: "ESXI"
         os_version: "{{hostvars[item].esx_os_version}}"
         host_credential:
-            username: "root"
-            password: "{{hostvars[item].ansible_ssh_pass}}"
-            thumbprint: "{{hostvars[item].sslthumb[0]}}"
+          username: "root"
+          password: "{{hostvars[item].ansible_ssh_pass}}"
+          thumbprint: "{{hostvars[item].sslthumb[0]}}"
         state: present
       with_items:
         - "{{groups['esx_hosts']}}"
       when:
         - groups['esx_hosts'] is defined
+        - hostvars['localhost'].unified_appliance == false
 
     - name: Create transport node for ESX hosts
       nsxt_transport_nodes:
@@ -248,6 +252,46 @@
         - "{{groups['esx_hosts']}}"
       when:
         - groups['esx_hosts'] is defined
+        - hostvars['localhost'].unified_appliance == false
+
+    - name: Create transport nodes for ESX hosts (2.4.0 and later)
+      nsxt_transport_nodes:
+        hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
+        username: "{{hostvars['localhost'].nsx_manager_username}}"
+        password: "{{hostvars['localhost'].nsx_manager_password}}"
+        validate_certs: False
+        resource_type: TransportNode
+        display_name: "{{hostvars[item].transport_node_name}}"
+        description: Transport Node for {{hostvars[item].ip}}
+        host_switch_spec:
+          resource_type: StandardHostSwitchSpec
+          host_switches:
+          - host_switch_profiles:
+            - name: "{{host_uplink_prof}}"
+              type: UplinkHostSwitchProfile
+            host_switch_name: "{{overlay_host_switch}}"
+            pnics: "{{pnic_list}}"
+            ip_assignment_spec:
+              resource_type: StaticIpPoolSpec
+              ip_pool_name: "{{vtep_ip_pool_name}}"
+        transport_zone_endpoints:
+        - transport_zone_name: "{{overlay_transport_zone}}"
+        node_deployment_info:
+          resource_type: "HostNode"
+          display_name: "{{hostvars[item].fabric_node_name}}"
+          ip_addresses: "{{hostvars[item].ip}}"
+          os_type: "ESXI"
+          os_version: "{{hostvars[item].esx_os_version}}"
+          host_credential:
+            username: "root"
+            password: "{{hostvars[item].ansible_ssh_pass}}"
+            thumbprint: "{{hostvars[item].sslthumb[0]}}"
+        state: present
+      with_items:
+        - "{{groups['esx_hosts']}}"
+      when:
+        - groups['esx_hosts'] is defined
+        - hostvars['localhost'].unified_appliance == true
 
 ###############################################################################
 # Tier 0 Router

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -183,7 +183,8 @@
       shell: I=0; while ! ping -c 1 -W 2 {{hostvars[item].ip}}; do I=$(( I + 1 )); [ $I -gt 60 ] && exit 1; done; exit 0
       with_items: "{{groups['controllers']}}"
 
-    - name: Add Edge VM
+    - name: Add Edge VM as fabric node
+      # nsxt_fabric_nodes has been deprecated as of 2.4.0
       nsxt_fabric_nodes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
@@ -218,6 +219,74 @@
             enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
         state: "present"
       with_items: "{{groups['edge_nodes']}}"
+      when:
+      - hostvars['localhost'].unified_appliance == false
+
+    - name: Add Edge VM as transport node
+      nsxt_transport_nodes:
+        hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
+        username: "{{hostvars['localhost'].nsx_manager_username}}"
+        password: "{{hostvars['localhost'].nsx_manager_password}}"
+        validate_certs: False
+        resource_type: "TransportNode"
+        display_name: "{{hostvars[item].transport_node_name}}"
+        description: Edge Transport Node for {{hostvars[item].ip}}
+        host_switch_spec:
+          resource_type: StandardHostSwitchSpec
+          host_switches:
+          - host_switch_profiles:
+            - name: "{{edge_uplink_prof}}"
+              type: UplinkHostSwitchProfile
+            host_switch_name: "{{overlay_host_switch}}"
+            pnics:
+            - device_name: fp-eth1
+              uplink_name: "{{uplink_1_name}}"
+            ip_assignment_spec:
+              resource_type: StaticIpPoolSpec
+              ip_pool_name: "{{vtep_ip_pool_name}}"
+          - host_switch_profiles:
+            - name: "{{edge_uplink_prof}}"
+              type: UplinkHostSwitchProfile
+            host_switch_name: "{{vlan_host_switch}}"
+            pnics:
+            - device_name: fp-eth0
+              uplink_name: "{{uplink_1_name}}"
+        transport_zone_endpoints:
+        - transport_zone_name: "{{overlay_transport_zone}}"
+        - transport_zone_name: "{{vlan_transport_zone}}"
+        node_deployment_info:
+          resource_type: "EdgeNode"
+          display_name: "{{hostvars[item].hostname}}"
+          ip_addresses:
+          - "{{hostvars[item].ip}}"
+          deployment_config:
+            form_factor: "{{hostvars[item].edge_deployment_size}}"
+            node_user_settings:
+              cli_password: "{{hostvars[item].edge_cli_password}}"
+              root_password: "{{hostvars[item].edge_root_password}}"
+            vm_deployment_config:
+              placement_type: VsphereDeploymentConfig
+              vc_id: "{{compute_manager.id}}"
+              data_network_ids:
+              - "{{hostvars[item].vc_uplink_network_for_edge}}"
+              - "{{hostvars[item].vc_overlay_network_for_edge}}"
+              - "{{hostvars[item].vc_management_network_for_edge}}"
+              management_network_id: "{{hostvars[item].vc_management_network_for_edge}}"
+              hostname: "{{hostvars[item].hostname}}"
+              compute_id: "{{hostvars[item].vc_cluster_for_edge}}"
+              storage_id: "{{hostvars[item].vc_datastore_for_edge}}"
+              default_gateway_addresses:
+              - "{{hostvars[item].default_gateway}}"
+              management_port_subnets:
+              - ip_addresses:
+                - "{{hostvars[item].ip}}"
+                prefix_length: "{{hostvars[item].prefix_length}}"
+              enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
+        state: present
+      with_items:
+      - "{{groups['edge_nodes']}}"
+      when:
+      - hostvars['localhost'].unified_appliance == true
 
     - name: Wait 120 seconds for edge nodes to become reachable
       shell: I=0; while ! ping -c 1 -W 2 {{hostvars[item].ip}}; do I=$(( I + 1 )); [ $I -gt 60 ] && exit 1; done; exit 0

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -141,15 +141,13 @@
         - hostvars['localhost'].resource_reservation_off == "true"
 
     - name: Deploy controller
-      # TODO: change back to nsxt_controller once nsx-t ansible is backward compatible
-      nsxt_controller_manager_auto_deployment:
+      nsxt_controllers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
         validate_certs: False
         deployment_requests:
-        - roles:
-          - CONTROLLER
+        - roles: CONTROLLER
           form_factor: "{{hostvars[item].controller_deployment_size}}"
           user_settings:
             cli_password: "{{hostvars[item].controller_cli_password}}"
@@ -175,44 +173,6 @@
         state: present
       with_items: "{{groups['controllers']}}"
       register: controller_response
-      when:
-        - hostvars['localhost'].unified_appliance == "false"
-
-    - name: Deploy controller manager (Unified Appliance)
-      nsxt_controller_manager_auto_deployment:
-        hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
-        username: "{{hostvars['localhost'].nsx_manager_username}}"
-        password: "{{hostvars['localhost'].nsx_manager_password}}"
-        validate_certs: False
-        deployment_requests:
-        - roles:
-          - CONTROLLER
-          - MANAGER
-          form_factor: "{{hostvars[item].controller_deployment_size}}"
-          user_settings:
-            cli_password: "{{hostvars['localhost'].nsx_manager_password}}"
-            root_password: "{{hostvars['localhost'].nsx_manager_password}}"
-          deployment_config:
-            placement_type: VsphereClusterNodeVMDeploymentConfig
-            vc_id: "{{compute_manager.id}}"
-            management_network_id: "{{hostvars[item].vc_management_network_for_controller}}"
-            hostname: "{{hostvars[item].hostname}}"
-            compute_id: "{{hostvars[item].vc_cluster_for_controller}}"
-            storage_id: "{{hostvars[item].vc_datastore_for_controller}}"
-            default_gateway_addresses:
-            - "{{hostvars[item].default_gateway}}"
-            management_port_subnets:
-            - ip_addresses:
-              - "{{hostvars[item].ip}}"
-              prefix_length: "{{hostvars[item].prefix_length}}"
-            dns_servers:
-              - "{{hostvars['localhost'].dns_server}}"
-            enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
-        state: present
-      with_items: "{{groups['controllers']}}"
-      register: controller_response
-      when:
-        - hostvars['localhost'].unified_appliance == "true"
 
     - name: Install ping
       apt:

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -174,6 +174,44 @@
         state: present
       with_items: "{{groups['controllers']}}"
       register: controller_response
+      when:
+        - hostvars['localhost'].unified_appliance == "false"
+
+    - name: Deploy controller manager (Unified Appliance)
+      nsxt_controllers:
+        hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
+        username: "{{hostvars['localhost'].nsx_manager_username}}"
+          password: "{{hostvars['localhost'].nsx_manager_password}}"
+          validate_certs: False
+          deployment_requests:
+          - roles:
+            - CONTROLLER
+            - MANAGER
+            form_factor: "{{hostvars[item].controller_deployment_size}}"
+            user_settings:
+              cli_password: "{{hostvars['localhost'].nsx_manager_password}}"
+              root_password: "{{hostvars['localhost'].nsx_manager_password}}"
+            deployment_config:
+              placement_type: VsphereClusterNodeVMDeploymentConfig
+              vc_id: "{{compute_manager.id}}"
+              management_network_id: "{{hostvars[item].vc_management_network_for_controller}}"
+              hostname: "{{hostvars[item].hostname}}"
+              compute_id: "{{hostvars[item].vc_cluster_for_controller}}"
+              storage_id: "{{hostvars[item].vc_datastore_for_controller}}"
+              default_gateway_addresses:
+              - "{{hostvars[item].default_gateway}}"
+              management_port_subnets:
+              - ip_addresses:
+                - "{{hostvars[item].ip}}"
+                prefix_length: "{{hostvars[item].prefix_length}}"
+              dns_servers:
+                - "{{hostvars['localhost'].dns_server}}"
+              enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
+          state: present
+      with_items: "{{groups['controllers']}}"
+      register: controller_response
+      when:
+        - hostvars['localhost'].unified_appliance == "true"
 
     - name: Install ping
       apt:

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -7,9 +7,7 @@
   tasks:
     - name: deploy NSX Manager OVA
       nsxt_deploy_ova:
-        vcenter: "{{hostvars['localhost'].vcenter_ip}}"
-        vcenter_user: "{{hostvars['localhost'].vcenter_username}}"
-        vcenter_passwd: "{{hostvars['localhost'].vcenter_password}}"
+        ovftool_path: "{{ovftool_bin_path}}"
         datacenter: "{{hostvars['localhost'].vcenter_datacenter}}"
         datastore: "{{hostvars['localhost'].vcenter_datastore}}"
         portgroup: "{{hostvars['localhost'].mgmt_portgroup}}"
@@ -24,9 +22,11 @@
         netmask: "{{hostvars['localhost'].netmask}}"
         admin_password: "{{hostvars['localhost'].nsx_manager_password}}"
         cli_password: "{{hostvars['localhost'].nsx_manager_password}}"
-        ovftool_path: "{{ovftool_bin_path}}"
         path_to_ova: "{{hostvars['localhost'].nsx_image_webserver}}"
         ova_file: "{{hostvars['localhost'].ova_file_name}}"
+        vcenter: "{{hostvars['localhost'].vcenter_ip}}"
+        vcenter_user: "{{hostvars['localhost'].vcenter_username}}"
+        vcenter_passwd: "{{hostvars['localhost'].vcenter_password}}"
         deployment_size: "{{hostvars['localhost'].nsx_manager_deployment_size}}"
         role: "{{hostvars['localhost'].nsx_manager_role}}"
         ssh_enabled: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
@@ -141,7 +141,8 @@
         - hostvars['localhost'].resource_reservation_off == "true"
 
     - name: Deploy controller
-      nsxt_controllers:
+      # TODO: change back to nsxt_controller once nsx-t ansible is backward compatible
+      nsxt_controller_manager_auto_deployment:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -178,7 +179,7 @@
         - hostvars['localhost'].unified_appliance == "false"
 
     - name: Deploy controller manager (Unified Appliance)
-      nsxt_controllers:
+      nsxt_controller_manager_auto_deployment:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -28,7 +28,7 @@
         path_to_ova: "{{hostvars['localhost'].nsx_image_webserver}}"
         ova_file: "{{hostvars['localhost'].ova_file_name}}"
         deployment_size: "{{hostvars['localhost'].nsx_manager_deployment_size}}"
-        role: "nsx-manager"
+        role: "{{hostvars['localhost'].nsx_manager_role}}"
         ssh_enabled: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
         allow_ssh_root_login: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
       register: ova_deploy_status
@@ -181,33 +181,33 @@
       nsxt_controllers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
-          password: "{{hostvars['localhost'].nsx_manager_password}}"
-          validate_certs: False
-          deployment_requests:
-          - roles:
-            - CONTROLLER
-            - MANAGER
-            form_factor: "{{hostvars[item].controller_deployment_size}}"
-            user_settings:
-              cli_password: "{{hostvars['localhost'].nsx_manager_password}}"
-              root_password: "{{hostvars['localhost'].nsx_manager_password}}"
-            deployment_config:
-              placement_type: VsphereClusterNodeVMDeploymentConfig
-              vc_id: "{{compute_manager.id}}"
-              management_network_id: "{{hostvars[item].vc_management_network_for_controller}}"
-              hostname: "{{hostvars[item].hostname}}"
-              compute_id: "{{hostvars[item].vc_cluster_for_controller}}"
-              storage_id: "{{hostvars[item].vc_datastore_for_controller}}"
-              default_gateway_addresses:
-              - "{{hostvars[item].default_gateway}}"
-              management_port_subnets:
-              - ip_addresses:
-                - "{{hostvars[item].ip}}"
-                prefix_length: "{{hostvars[item].prefix_length}}"
-              dns_servers:
-                - "{{hostvars['localhost'].dns_server}}"
-              enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
-          state: present
+        password: "{{hostvars['localhost'].nsx_manager_password}}"
+        validate_certs: False
+        deployment_requests:
+        - roles:
+          - CONTROLLER
+          - MANAGER
+          form_factor: "{{hostvars[item].controller_deployment_size}}"
+          user_settings:
+            cli_password: "{{hostvars['localhost'].nsx_manager_password}}"
+            root_password: "{{hostvars['localhost'].nsx_manager_password}}"
+          deployment_config:
+            placement_type: VsphereClusterNodeVMDeploymentConfig
+            vc_id: "{{compute_manager.id}}"
+            management_network_id: "{{hostvars[item].vc_management_network_for_controller}}"
+            hostname: "{{hostvars[item].hostname}}"
+            compute_id: "{{hostvars[item].vc_cluster_for_controller}}"
+            storage_id: "{{hostvars[item].vc_datastore_for_controller}}"
+            default_gateway_addresses:
+            - "{{hostvars[item].default_gateway}}"
+            management_port_subnets:
+            - ip_addresses:
+              - "{{hostvars[item].ip}}"
+              prefix_length: "{{hostvars[item].prefix_length}}"
+            dns_servers:
+              - "{{hostvars['localhost'].dns_server}}"
+            enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
+        state: present
       with_items: "{{groups['controllers']}}"
       register: controller_response
       when:

--- a/pipelines/nsx-t-install.yml
+++ b/pipelines/nsx-t-install.yml
@@ -130,7 +130,7 @@ resources:
   type: git
   source:
     uri: https://github.com/vmware/ansible-for-nsxt.git
-    branch: master
+    branch: ((nsxt_ansible_branch))
 
 - name: ovftool
   type: file-url

--- a/pipelines/nsx-t-install.yml
+++ b/pipelines/nsx-t-install.yml
@@ -33,6 +33,7 @@ nsx_t_gen_params: &nsx-t-gen-params
   vtep_ip_pool_start_int: ((vtep_ip_pool_start))
   vtep_ip_pool_end_int: ((vtep_ip_pool_end))
 
+  unified_appliance_int: ((unified_appliance))
   resource_reservation_off_int: ((resource_reservation_off))
   controller_ips_int: ((controller_ips))
   controller_default_gateway_int: ((controller_default_gateway))

--- a/sample_parameters/PAS_and_PKS/nsx_pipeline_config.yml
+++ b/sample_parameters/PAS_and_PKS/nsx_pipeline_config.yml
@@ -68,7 +68,7 @@ vc_datacenter_for_controller: RegionA01
 vc_cluster_for_controller: RegionA01-MGMT
 vc_datastore_for_controller: iscsi
 vc_management_network_for_controller: "ESXi-RegionA01-vDS-COMP"
-controller_shared_secret: "VMware1!VMware1!"
+controller_shared_secret: "VMware1!VMware1!" # Does not need to be configured in unified appliance
 
 ## Edge nodes
 edge_ips: 192.168.110.37,192.168.110.38    #comma separated based in number of required edges

--- a/sample_parameters/PAS_only/nsx_pipeline_config.yml
+++ b/sample_parameters/PAS_only/nsx_pipeline_config.yml
@@ -68,7 +68,7 @@ vc_datacenter_for_controller: RegionA01
 vc_cluster_for_controller: RegionA01-MGMT
 vc_datastore_for_controller: iscsi
 vc_management_network_for_controller: "ESXi-RegionA01-vDS-COMP"
-controller_shared_secret: "VMware1!VMware1!"
+controller_shared_secret: "VMware1!VMware1!"  # Does not need to be configured in unified appliance
 
 ## Edge nodes
 edge_ips: 192.168.110.37,192.168.110.38    #comma separated based in number of required edges

--- a/sample_parameters/PKS_only/nsx_pipeline_config.yml
+++ b/sample_parameters/PKS_only/nsx_pipeline_config.yml
@@ -68,7 +68,7 @@ vc_datacenter_for_controller: RegionA01
 vc_cluster_for_controller: RegionA01-MGMT
 vc_datastore_for_controller: iscsi
 vc_management_network_for_controller: "ESXi-RegionA01-vDS-COMP"
-controller_shared_secret: "VMware1!VMware1!"
+controller_shared_secret: "VMware1!VMware1!"  # Does not need to be configured in unified appliance
 
 ## Edge nodes
 edge_ips: 192.168.110.37,192.168.110.38    #comma separated based in number of required edges

--- a/tasks/install-nsx-t/get_mo_ref_id.py
+++ b/tasks/install-nsx-t/get_mo_ref_id.py
@@ -185,7 +185,7 @@ class HostsFileWriter(object):
 
     def modify_deploy_size_if_matched(self, line):
         new_line = line
-        if line and 'deployment_size' in line:
+        if line and 'deployment_size' in line and 'nsx_manager' not in line:
             value = line.split('=')[-1].strip(" \"'")
             var_name = line.split('=')[0]
             new_line = '%s=%s' % (var_name, value.upper())

--- a/tasks/install-nsx-t/modify_options.py
+++ b/tasks/install-nsx-t/modify_options.py
@@ -1,0 +1,27 @@
+import fileinput
+import os
+
+TOPOLOGY_FILE = "basic_topology.yml"
+
+
+def add_dns_server_option():
+    dns_servers_spec = os.getenv('dns_server_int')
+    for line in fileinput.FileInput(TOPOLOGY_FILE, inplace=1):
+        if "hostvars[item].prefix_length" in line:
+            leading_spaces = len(line) - len(line.lstrip()) - 2
+            dns_line = ' ' * leading_spaces
+            if ',' not in dns_servers_spec:
+                dns_line += "dns_servers: \"{{hostvars['localhost'].dns_server}}\""
+            else:
+                dns_servers = dns_servers_spec.split(', ')
+                dns_line += "dns_servers:"
+                for server in dns_servers:
+                    dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
+            line = line.replace(line, line + dns_line + '\n')
+        print line,
+        # For Python3 use following line instead
+        # print(line, end='')
+
+
+if __name__ == "__main__":
+    add_dns_server_option()

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -73,6 +73,17 @@ python get_mo_ref_id.py --host $vcenter_ip_int --user $vcenter_username_int --pa
 cp hosts.out ${PIPELINE_DIR}/nsxt_yaml/basic_topology.yml ${PIPELINE_DIR}/nsxt_yaml/vars.yml nsxt-ansible/
 cd nsxt-ansible
 
+if [[ "$unified_appliance_int" == "true" ]]; then
+    sed -i 's/Deploy controller/Deploy controller-manager/g' basic_topology.yml
+    sed -i 's/nsxt_controllers/nsxt_controller_manager_auto_deployment/g' basic_topology.yml
+    sed -i 's/roles: CONTROLLER/roles: [CONTROLLER, MANAGER]/g' basic_topology.yml
+    sed -i 's/vc_id/vc_name/g; s/compute_manager.id/compute_manager_name/g' basic_topology.yml
+    sed -i '/clustering_config/d; /clustering_type/d; /shared_secret/d; /join_to_existing_cluster/d' basic_topology.yml
+    DNS_SERVER_LINE="\- \"{{hostvars[\'localhost\'].dns_server}}\""
+    sed -i "/hostvars\[item\].prefix_length/a \ \ \ \ \ \ \ \ \ \ \ \ dns_servers: " basic_topology.yml
+    sed -i "/dns_servers:/a \ \ \ \ \ \ \ \ \ \ \ \ $DNS_SERVER_LINE" basic_topology.yml
+fi
+
 # Deploy the ovas if its not up
 echo "Installing ovftool"
 install_ovftool

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -91,9 +91,6 @@ install_ovftool
 cp ${PIPELINE_DIR}/tasks/install-nsx-t/turn_off_reservation.py ./
 cp ${PIPELINE_DIR}/tasks/config-nsx-t-extras/*.py ./
 
-# Testing
-exit 1
-
 ansible-playbook $DEBUG -i hosts.out basic_topology.yml
 STATUS=$?
 

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -79,6 +79,10 @@ install_ovftool
 
 cp ${PIPELINE_DIR}/tasks/install-nsx-t/turn_off_reservation.py ./
 cp ${PIPELINE_DIR}/tasks/config-nsx-t-extras/*.py ./
+
+# Testing
+exit 0
+
 ansible-playbook $DEBUG -i hosts.out basic_topology.yml
 STATUS=$?
 

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -76,8 +76,7 @@ function modify_ansible_tasks_for_unified_appliance {
     sed -i '/clustering_config/,+3 d' basic_topology.yml
 
     # DNS server needs to be specified for static IPs
-    DNS_SERVER="\"{{hostvars[\'localhost\'].dns_server}}\""
-    sed -i "/hostvars\[item\].prefix_length/a \ \ \ \ \ \ \ \ \ \ \ \ dns_servers: [$DNS_SERVER]" basic_topology.yml
+    python modify_options.py
 }
 
 DEBUG=""
@@ -91,6 +90,7 @@ python get_mo_ref_id.py --host $vcenter_ip_int --user $vcenter_username_int --pa
 
 cp hosts.out ${PIPELINE_DIR}/nsxt_yaml/basic_topology.yml ${PIPELINE_DIR}/nsxt_yaml/vars.yml nsxt-ansible/
 cd nsxt-ansible
+cp ${PIPELINE_DIR}/tasks/install-nsx-t/modify_options.py ./
 
 if [[ "$unified_appliance_int" == "true" ]]; then
     modify_ansible_tasks_for_unified_appliance

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -81,7 +81,7 @@ cp ${PIPELINE_DIR}/tasks/install-nsx-t/turn_off_reservation.py ./
 cp ${PIPELINE_DIR}/tasks/config-nsx-t-extras/*.py ./
 
 # Testing
-exit 0
+exit 1
 
 ansible-playbook $DEBUG -i hosts.out basic_topology.yml
 STATUS=$?


### PR DESCRIPTION
## Change summary
- nsx-t versions prior to 2.4.0 will use _ansible-for-nsxt/v1.0.0_ branch and nsx-t 2.4.0 will use the _ansible-for-nsxt/master_ branch.
- Both manager OVA and deployed controllers will serve _nsx-manager_ and _nsx-controller_ roles.
- _basic_topology.yml_ will be modified in runtime based on nsx-t version