### PR TITLE
Don't Add Management Network to Edge data_network_ids

### DIFF
--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -307,7 +307,7 @@
               type: UplinkHostSwitchProfile
             host_switch_name: "{{overlay_host_switch}}"
             pnics:
-            - device_name: fp-eth1
+            - device_name: fp-eth0
               uplink_name: "{{uplink_1_name}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
@@ -317,7 +317,7 @@
               type: UplinkHostSwitchProfile
             host_switch_name: "{{vlan_host_switch}}"
             pnics:
-            - device_name: fp-eth0
+            - device_name: fp-eth1
               uplink_name: "{{uplink_1_name}}"
         transport_zone_endpoints:
         - transport_zone_name: "{{overlay_transport_zone}}"
@@ -336,9 +336,8 @@
               placement_type: VsphereDeploymentConfig
               vc_name: "{{compute_manager_name}}"
               data_network_ids:
-              - "{{hostvars[item].vc_uplink_network_for_edge}}"
               - "{{hostvars[item].vc_overlay_network_for_edge}}"
-              - "{{hostvars[item].vc_management_network_for_edge}}"
+              - "{{hostvars[item].vc_uplink_network_for_edge}}"
               management_network_id: "{{hostvars[item].vc_management_network_for_edge}}"
               hostname: "{{hostvars[item].hostname}}"
               compute_id: "{{hostvars[item].vc_cluster_for_edge}}"


### PR DESCRIPTION
This is because data networks are for overlay and vlan uplink. The
management network is for NSX MP to Edge connection. The management
network should not be used as data network (in theory). If in practice
the management network and vlan uplink network are the same, the user
still can specify the same value for vc_uplink_network_for_edge
and vc_management_network_for_edge.