### PR TITLE
docker-image: follow-up concerning internal run-sequence of 'nsx-t-install' image

### DIFF
--- a/docker_image/Dockerfile
+++ b/docker_image/Dockerfile
@@ -1,14 +1,28 @@
-FROM ubuntu:18.04
-ADD run.sh /home/run.sh
+# Docker build file for 'nsx-t-datacenter-ci-pipelines'
+FROM     ubuntu:18.04
 
-# https://docs.docker.com/compose/install/#install-compose
-RUN apt-get update && \
-    apt-get install -y vim curl openssh-client git wget && \
-    curl -sSL https://get.docker.com/ | sh && \
-    curl -L --fail https://github.com/docker/compose/releases/download/1.23.2/run.sh -o /usr/local/bin/docker-compose && \
-    chmod +x /usr/local/bin/docker-compose && \
-    # download and install fly CLI
-    wget -O /usr/local/bin/fly https://github.com/Concourse/Concourse/releases/download/v4.2.1/fly_linux_amd64 && \
-    chmod +x /usr/local/bin/fly
+# install additional linux packages
+RUN     apt-get update && \
+        apt-get install -y vim curl openssh-client git wget
+    
+# add docker compose
+RUN     cd /usr/local/bin/ && \
+        wget -q -O - https://get.docker.com/ | sh && \
+        wget -q -O docker-compose https://github.com/docker/compose/releases/download/1.23.2/run.sh && \
+        chmod +x docker-compose && \
+        file ${PWD}/docker-compose
 
-ENTRYPOINT ["/home/run.sh"]
+# add fly
+# wget -q -O - https://github.com/concourse/concourse/releases/download/v5.3.0/fly-5.3.0-linux-amd64.tgz | tar -zxf -
+RUN     cd /usr/local/bin && \
+        wget -q -O fly https://github.com/Concourse/Concourse/releases/download/v4.2.1/fly_linux_amd64 && \
+        chmod +x fly && \
+        file ${PWD}/fly
+
+# add custom code
+ADD     Dockerfile        /Dockerfile
+ADD     run.sh            /home/run.sh
+RUN     chmod +x /home/run.sh
+
+# application launch
+ENTRYPOINT         ["/home/run.sh"]

--- a/docker_image/README.md
+++ b/docker_image/README.md
@@ -1,0 +1,30 @@
+# how to build the 'nsx-t-install' image
+
+## install docker
+... install docker for your platform ...
+
+## clone this repo and build
+```
+git clone https://github.com/vmware/nsx-t-datacenter-ci-pipelines.git
+docker build -t nsx-t-install ./nsx-t-datacenter-ci-pipelines/docker_image
+```
+
+## run the container manually
+(Assuming you have a _nsx_pipeline_config.yml_ already prepared in _/home/concourse_)
+```
+docker run -it --name nsx-t-installer --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /home/concourse:/home/concourse \
+  nsx-t-install -CONCOURSE_URL http://<your_ip>:8080 
+```
+
+## run the container assisted
+```
+sh ./nsx-t-datacenter-ci-pipelines/docker_image/run.nsx-t-install-er.sh
+```
+
+## manually destroy all 
+```
+docker ps --format "{{.Names}}" | grep -e "^concourse" -e "^nsx-t-installer" -e "^nginx-" | xargs docker stop
+rm -f /home/concourse/nsx_pipeline_config.pid
+```

--- a/docker_image/nsx-t-install-05202019-ua.tar
+++ b/docker_image/nsx-t-install-05202019-ua.tar
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aee9fddfd8d38a2ff182f1e93075c811441730c3dca3f88dc182cb4ca7654a0b
-size 546060800

--- a/docker_image/run.nsx-t-install-er.sh
+++ b/docker_image/run.nsx-t-install-er.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# launcher-helper for nsx-t-installer container
+
+export MyIf=`ip route | grep "default" | awk '{ print $5; }'`
+export MyIp=`ip addr show $MyIf | grep ".*inet [0-9]*.[0-9]*.[0-9]*.[0-9]*/[0-9]* " | tr '/' ' ' | awk '{ print $2; }'`
+export MyDns=`grep ^nameserver /etc/resolv.conf | shuf | tail -n1 | awk '{ print $NF; }'`
+
+echo " ---->  MyIf: ${MyIf}  |  MyIp: ${MyIp}  |  DNS: ${MyDns}  <---- "
+
+# replace '-it' with '-d' for non-interactive
+docker run --rm --name nsx-t-installer -it \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /home/concourse:/home/concourse \
+  nsx-t-install \
+  -CONCOURSE_URL "http://${MyIp}:8080" \
+  -EXTERNAL_DNS "${MyDns}" \
+  -VMWARE_USER "MyVmwLogin" \
+  -VMWARE_PASS "MyVmwPass"

--- a/docker_image/run.sh
+++ b/docker_image/run.sh
@@ -1,170 +1,324 @@
 #!/usr/bin/env bash
-# Set this via a env var
-# CONCOURSE_URL="http://10.33.75.99:8080"
-# EXTERNAL_DNS=<dns_ip>
-# IMAGE_WEBSERVER_PORT=<port_number>
-# VMWARE_USER
-# VMWARE_PASSWORD
-# NSXT_VERSION
 
-ROOT_WORK_DIR="/home/workspace"
-BIND_MOUNT_DIR="/home/concourse"
-CONFIG_FILE_NAME="nsx_pipeline_config.yml"
+# add some documentation and a summary here
 
-if [[ ! -e ${BIND_MOUNT_DIR}/${CONFIG_FILE_NAME} ]]; then
-	echo "Config file ${BIND_MOUNT_DIR}/${CONFIG_FILE_NAME} not found, exiting"
-	exit 1
-fi
+###
+# inital startup, arg parsing and dealing with values
+###
 
-# download the ovftool and OVA files
-cd $BIND_MOUNT_DIR
-ova_file_name=$(ls -l *.ova | sed 's/.* nsx/nsx/;s/ova.*/ova/' | tail -n1)
-ovftool_file_name=$(ls -l *.bundle | sed 's/.* VMware-ovftool/VMware-ovftool/;s/bundle.*/bundle/' | tail -n1)
+set -a -e
 
-nsxt_version=2.4.0
-if [[ $ova_file_name != "" ]]; then
-    nsxt_version=$(echo ${ova_file_name##*-} | head -c5)
-elif [[ $NSXT_VERSION != "" ]]; then
-	nsxt_version=$NSXT_VERSION
-fi
+function log { echo "---> $@"; }
+function error { echo "ERROR: $@"; exit 2; }
 
-if [[ $ova_file_name == "" ]] || [[ $ovftool_file_name == "" ]]; then
-	#ovftool_file_name="VMware-ovftool-4.3.0-7948156-lin.x86_64.bundle"
-	#ova_file_name="nsx-unified-appliance-2.2.0.0.0.8680778.ova"
-	set -e
-	docker run -itd --name vmw-cli -e VMWINDEXDIR="/state" -e VMWUSER=$VMWARE_USER -e VMWPASS=$VMWARE_PASSWORD -v ${BIND_MOUNT_DIR}:/files --entrypoint=sh apnex/vmw-cli
+export ROOT_WORK_DIR=/home/workspace
+export BIND_MOUNT_DIR=/home/concourse
 
-	docker exec -t vmw-cli vmw-cli index OVFTOOL430
-	ovftool_file_name=$(docker exec -t vmw-cli vmw-cli find fileType:bundle,version:4.3 | grep VMware-ovftool | sed 's/.* VMware-ovftool/VMware-ovftool/;s/bundle.*/bundle/' | tail -n1)
-	docker exec -t vmw-cli vmw-cli get $ovftool_file_name
+log "${FUNCNAME[0]}: parsing arguments"
+while [ "$1" != "" ]; do
+case "$1" in
+    "-CONCOURSE_URL")
+        shift; export CONCOURSE_URL=$1
+        shift; continue
+        ;;
+    "-EXTERNAL_DNS")
+        shift; export EXTERNAL_DNS=$1
+        shift; continue
+        ;;
+    "-IMAGE_WEBSERVER_PORT")
+        shift; export IMAGE_WEBSERVER_PORT=$1
+        shift; continue
+        ;;
+    "-VMWARE_USER")
+        shift; export VMWARE_USER=$1
+        shift; continue
+        ;;
+    "-VMWARE_PASS")
+        shift; export VMWARE_PASS=$1
+        shift; continue
+        ;;        
+    "-NSXT_VERSION")
+        shift; export NSXT_VERSION=$1
+        shift; continue
+        ;;            
+    "-CONFIG_FILE_NAME")
+        shift; export CONFIG_FILE_NAME=$1
+        shift; continue
+        ;;
+    "-EXTERNAL_DNS")
+        shift; export EXTERNAL_DNS=$1
+        shift; continue
+        ;;
+    "bash"|"/bin/bash"|"sh"|"/bin/sh")
+        log "${FUNCNAME[0]}: bypass into shell"
+        /bin/bash --login
+        exit $?
+        ;;
+    *)
+        error "unknown argument '$1'"
+        shift
+        ;;
+esac
+done
 
-	version_no_dots=$(echo $nsxt_version | sed 's/\.//g')
-	docker exec -t vmw-cli vmw-cli index NSX-T-${version_no_dots}
-	ova_file_name=$(docker exec -t vmw-cli vmw-cli find fileType:ova,version:${nsxt_version} | grep nsx-unified-appliance | sed 's/.* nsx/nsx/;s/ova.*/ova/' | tail -n1)
-	docker exec -t vmw-cli vmw-cli get $ova_file_name
-	docker stop vmw-cli
-	docker rm vmw-cli
 
-        if [[ $ova_file_name == "" ]]; then
-		echo "OVA not found for NSX version $nsxt_version. Please specify a supported version and recreate the container."
-		exit 1
-	fi
-	set +e
-fi
+# defaults
+if [ -z "${EXTERNAL_DNS}" ]; then             export EXTERNAL_DNS=`grep ^nameserver /etc/resolv.conf | shuf | awk 'END{print $2}'`; fi
+if [ -z "${IMAGE_WEBSERVER_PORT}" ]; then     export IMAGE_WEBSERVER_PORT=40001; fi
+if [ -z "${NSXT_VERSION}" ]; then             export NSXT_VERSION=2.4.1; fi
+if [ -z "${CONFIG_FILE_NAME}" ]; then         export CONFIG_FILE_NAME=nsx_pipeline_config.yml; fi
 
+# some more defaults
+export CONCOURSE_TARGET=nsx-concourse
+export PIPELINE_NAME=nsx-t-install
+my_own_github_url=https://github.com/vmware/nsx-t-datacenter-ci-pipelines.git
+concourse_version=4.2.1
 unified_appliance=true
 nsx_t_pipeline_branch=nsxt_2.4.0
 nsxt_ansible_branch=master
+#version_num=$(echo $nsxt_version | cut -d'.' -f1)
+#version_sub_num=$(echo $nsxt_version | cut -d'.' -f2)
+#if [[ $version_num -le 2 ]] && [[ $version_sub_num -le 3 ]]; then
+#    unified_appliance=false
+#    nsx_t_pipeline_branch=nsxt_2.3.0
+#    nsxt_ansible_branch=v1.0.0
+#fi
+#if [[ $PIPELINE_BRANCH != "" ]]; then
+#    nsx_t_pipeline_branch=$PIPELINE_BRANCH
+#fi
 
-version_num=$(echo $nsxt_version | cut -d'.' -f1)
-version_sub_num=$(echo $nsxt_version | cut -d'.' -f2)
-if [[ $version_num -le 2 ]] && [[ $version_sub_num -le 3 ]]; then
-    unified_appliance=false
-    nsx_t_pipeline_branch=nsxt_2.3.0
-    nsxt_ansible_branch=v1.0.0
+export pipeline_internal_config=${CONFIG_FILE_NAME::-4}.internal.yml
+export pipeline_dir=${ROOT_WORK_DIR}/nsx-t-datacenter-ci-pipelines
+
+# verify
+if [ -z "${CONCOURSE_URL}" ]; then error "CONCOURSE_URL must be specified like http://192.168.18.15:8080"; fi
+if [ ! -e ${BIND_MOUNT_DIR}/${CONFIG_FILE_NAME} ]; then error "Config file ${BIND_MOUNT_DIR}/${CONFIG_FILE_NAME} not found, exiting"; fi
+
+# some additional stuff about myself
+pidfile=${BIND_MOUNT_DIR}/${CONFIG_FILE_NAME::-4}.pid
+if [ -e $pidfile ]; then
+    echo "${pidfile} already exists, aborting";
+    exit 3
 fi
 
-if [[ $PIPELINE_BRANCH != "" ]]; then
-    nsx_t_pipeline_branch=$PIPELINE_BRANCH
-fi
 
-pipeline_internal_config="pipeline_config_internal.yml"
-echo "ovftool_file_name: $ovftool_file_name" > $pipeline_internal_config
-echo "ova_file_name: $ova_file_name" >> $pipeline_internal_config
-echo "unified_appliance: $unified_appliance" >> $pipeline_internal_config
-echo "nsx_t_pipeline_branch: $nsx_t_pipeline_branch" >> $pipeline_internal_config
-echo "nsxt_ansible_branch: $nsxt_ansible_branch" >> $pipeline_internal_config
+###
+# fetch requirements on startup
+###
 
-# start a web server to host static files such as ovftool and NSX manager OVA
-docker run --name nginx-server -v ${BIND_MOUNT_DIR}:/usr/share/nginx/html:ro -p ${IMAGE_WEBSERVER_PORT}:80 -d nginx
+function init-download-ova {
+    log "${FUNCNAME[0]}: download the ovftool and OVA files"
+    cd $BIND_MOUNT_DIR
+    ova_file_name=$(ls -l *.ova | sed 's/.* nsx/nsx/;s/ova.*/ova/' | tail -n1)
+    ovftool_file_name=$(ls -l *.bundle | sed 's/.* VMware-ovftool/VMware-ovftool/;s/bundle.*/bundle/' | tail -n1)
+    nsxt_version=2.4.0
+    if [[ $NSXT_VERSION != "" ]]; then
+        nsxt_version=$NSXT_VERSION
+    fi
+    
+    if [[ $NSXT_VERSION == "" ]]; then NSXT_VERSION=2.3.0; fi
+    
+    
+    
 
-mkdir -p $ROOT_WORK_DIR
-cd $ROOT_WORK_DIR
+    if [[ $ova_file_name == "" ]] || [[ $ovftool_file_name == "" ]]; then
+        #ovftool_file_name="VMware-ovftool-4.3.0-7948156-lin.x86_64.bundle"
+        #ova_file_name="nsx-unified-appliance-2.2.0.0.0.8680778.ova"
+        set -e
+        set -o xtrace
+        docker run -itd --name vmw-cli -e VMWINDEXDIR="/state" -e VMWUSER=$VMWARE_USER -e VMWPASS=$VMWARE_PASS -v ${BIND_MOUNT_DIR}:/files --entrypoint=sh apnex/vmw-cli
 
-#git clone https://github.com/concourse/concourse-docker.git
-#concourse_docker_dir=${ROOT_WORK_DIR}/concourse-docker
-#cp ${concourse_docker_dir}/keys/generate $BIND_MOUNT_DIR
-#./generate
+        docker exec -t vmw-cli vmw-cli index OVFTOOL430
+        ovftool_file_name=$(docker exec -t vmw-cli vmw-cli find fileType:bundle,version:4.3 | grep VMware-ovftool | sed 's/.* VMware-ovftool/VMware-ovftool/;s/bundle.*/bundle/' | tail -n1)
+        docker exec -t vmw-cli vmw-cli get $ovftool_file_name
 
-git clone -b $nsx_t_pipeline_branch --single-branch https://github.com/vmware/nsx-t-datacenter-ci-pipelines.git
-pipeline_dir=${ROOT_WORK_DIR}/nsx-t-datacenter-ci-pipelines
-cp ${pipeline_dir}/docker_compose/docker-compose.yml $BIND_MOUNT_DIR
-cp ${pipeline_dir}/functions/generate-keys.sh $BIND_MOUNT_DIR
+        version_no_dots=$(echo $nsxt_version | sed 's/\.//g')
+        docker exec -t vmw-cli vmw-cli index NSX-T-${version_no_dots}
+        ova_file_name=$(docker exec -t vmw-cli vmw-cli find fileType:ova,version:${nsxt_version} | grep nsx-unified-appliance | sed 's/.* nsx/nsx/;s/ova.*/ova/' | tail -n1)
+        docker exec -t vmw-cli vmw-cli get $ova_file_name
+        docker stop vmw-cli
+        docker rm vmw-cli
 
-cd $BIND_MOUNT_DIR
-chmod +x generate-keys.sh
-./generate-keys.sh
+        if [[ $ova_file_name == "" ]]; then
+            echo "OVA not found for NSX version $nsxt_version. Please specify a supported version and recreate the container."
+            exit 1
+        fi
+        set +o xtrace
+        set +e
+    fi
+    
+    export ova_file_name 
+    export ovftool_file_name
+}
+init-download-ova
 
-# prepare the yaml for docker compose
-concourse_version=4.2.1
-sed -i "0,/^ *- CONCOURSE_EXTERNAL_URL/ s|CONCOURSE_EXTERNAL_URL.*$|CONCOURSE_EXTERNAL_URL=${CONCOURSE_URL}|" docker-compose.yml
-sed -i "0,/^ *- CONCOURSE_GARDEN_DNS_SERVER/ s|CONCOURSE_GARDEN_DNS_SERVER.*$|CONCOURSE_GARDEN_DNS_SERVER=${EXTERNAL_DNS}|" docker-compose.yml
-sed  -i "/^ *image: concourse\/concourse/ s|concourse/concourse.*$|concourse/concourse:$concourse_version|g" docker-compose.yml
 
-# If proxy env vars not set, remove the settings
-proxy_patterns=("http_proxy_url" "https_proxy_url" "no_proxy" "HTTP_PROXY" "HTTPS_PROXY" "NO_PROXY")
-if [[ -z "$HTTP_PROXY" ]] || [[ -z "HTTPS_PROXY" ]]; then
-        for p in "${proxy_patterns[@]}"; do
-                sed -i "/$p/d" docker-compose.yml
-        done
+function init-fetch-concourse {
+    log "${FUNCNAME[0]}: fetch and prepare concourse"
+    mkdir -p $ROOT_WORK_DIR
+    cd $ROOT_WORK_DIR
+
+    #git clone https://github.com/concourse/concourse-docker.git
+    #concourse_docker_dir=${ROOT_WORK_DIR}/concourse-docker
+    #cp ${concourse_docker_dir}/keys/generate $BIND_MOUNT_DIR
+    #./generate
+    git clone -b $nsx_t_pipeline_branch --single-branch $my_own_github_url
+    cp ${pipeline_dir}/docker_compose/docker-compose.yml $BIND_MOUNT_DIR
+    cp ${pipeline_dir}/functions/generate-keys.sh $BIND_MOUNT_DIR
+
+    cd $BIND_MOUNT_DIR
+    chmod +x generate-keys.sh
+    if [ ! -d keys/ ]; then
+        ./generate-keys.sh
+    fi
+}
+init-fetch-concourse
+
+
+function init-adjust-config {
+    log "${FUNCNAME[0]}: strictly overwriting 'nsx_image_webserver'-value in ${CONFIG_FILE_NAME} - sorry for that"
+    websrv="`echo $CONCOURSE_URL | rev | cut -d':' -f 2- | rev`:${IMAGE_WEBSERVER_PORT}"
+    sed -i 's%^nsx_image_webserver:.*%nsx_image_webserver: '${websrv}'%g' ${BIND_MOUNT_DIR}/${CONFIG_FILE_NAME}
+
+    log "${FUNCNAME[0]}: writing additional pipeline configs"
+
+    echo "ovftool_file_name: $ovftool_file_name" > $pipeline_internal_config
+    echo "ova_file_name: $ova_file_name" >> $pipeline_internal_config
+    echo "unified_appliance: $unified_appliance" >> $pipeline_internal_config
+    echo "nsx_t_pipeline_branch: $nsx_t_pipeline_branch" >> $pipeline_internal_config
+    echo "nsxt_ansible_branch: $nsxt_ansible_branch" >> $pipeline_internal_config
+    
+    log "${FUNCNAME[0]}: prepare the yaml for docker compose"
+    sed -i "0,/^ *- CONCOURSE_EXTERNAL_URL/ s|CONCOURSE_EXTERNAL_URL.*$|CONCOURSE_EXTERNAL_URL=${CONCOURSE_URL}|" docker-compose.yml
+    sed -i "0,/^ *- CONCOURSE_GARDEN_DNS_SERVER/ s|CONCOURSE_GARDEN_DNS_SERVER.*$|CONCOURSE_GARDEN_DNS_SERVER=${EXTERNAL_DNS}|" docker-compose.yml
+    sed  -i "/^ *image: concourse\/concourse/ s|concourse/concourse.*$|concourse/concourse:$concourse_version|g" docker-compose.yml
+
+    # If proxy env vars not set, remove the settings
+    proxy_patterns=("http_proxy_url" "https_proxy_url" "no_proxy" "HTTP_PROXY" "HTTPS_PROXY" "NO_PROXY")
+    if [[ -z "$HTTP_PROXY" ]] || [[ -z "HTTPS_PROXY" ]]; then
+            for p in "${proxy_patterns[@]}"; do
+                    sed -i "/$p/d" docker-compose.yml
+            done
+    else
+            sed -i "0,/^ *- HTTP_PROXY/ s|HTTP_PROXY.*$|HTTP_PROXY=${HTTP_PROXY}|" docker-compose.yml
+            sed -i "0,/^ *- http_proxy_url/ s|http_proxy_url.*$|http_proxy_url=${HTTP_PROXY}|" docker-compose.yml
+
+            sed -i "0,/^ *- HTTPS_PROXY/ s|HTTPS_PROXY.*$|HTTPS_PROXY=${HTTPS_PROXY}|" docker-compose.yml
+            sed -i "0,/^ *- https_proxy_url/ s|https_proxy_url.*$|https_proxy_url=${HTTPS_PROXY}|" docker-compose.yml
+
+            sed -i "0,/^ *- NO_PROXY/ s|NO_PROXY.*$|NO_PROXY=${NO_PROXY}|" docker-compose.yml
+            sed -i "0,/^ *- no_proxy/ s|no_proxy.*$|no_proxy=${NO_PROXY}|" docker-compose.yml
+    fi
+    #sed -i "0,/^ *- CONCOURSE_GARDEN_NETWORK/ s|- CONCOURSE_GARDEN_NETWORK.*$|#- CONCOURSE_GARDEN_NETWORK|" docker-compose.yml
+    #sed -i "/^ *- CONCOURSE_EXTERNAL_URL/ a\    - CONCOURSE_NO_REALLY_I_DONT_WANT_ANY_AUTH=true" docker-compose.yml
+
+}
+init-adjust-config
+
+###
+# actually start bits an pieces
+###
+echo ${HOSTNAME} > $pidfile
+
+function shutdown-all {
+    set +a
+    log "${FUNCNAME[0]}: terminate!"
+    fly-stop
+    shutdown-internal-webserver
+    shutdown-concourse-compose
+    rm -f $pidfile $pipeline_internal_config $BIND_MOUNT_DIR/docker-compose.yml
+    log "${FUNCNAME[0]}: byebye"
+    exit 0
+}
+
+function shutdown-internal-webserver {
+    log "${FUNCNAME[0]}: stoping the static webserver"
+    while docker ps --format "{{.Names}}" | grep concourse_nginx-$HOSTNAME | xargs docker stop 2> /dev/null; do  sleep 0.1;   done;
+}
+
+function startup-internal-webserver {
+    log "${FUNCNAME[0]}: start a web server to host static files such as ovftool and NSX manager OVA"
+    docker run --rm --name concourse_nginx-$HOSTNAME -v ${BIND_MOUNT_DIR}:/usr/share/nginx/html:ro -p ${IMAGE_WEBSERVER_PORT}:80 -d nginx
+}
+startup-internal-webserver
+
+
+function shutdown-concourse-compose {
+    log "${FUNCNAME[0]}: bringing down Concourse server cluster"
+    docker-compose down
+}
+function startup-concourse-compose {
+    log "${FUNCNAME[0]}: bringing up Concourse server in a docker-compose cluster"
+    docker-compose up -d
+    echo -n "wating for cluster "
+    # waiting for the concourse API server to start up
+    while ! curl -s -o /dev/null $CONCOURSE_URL ; do
+        if [ ! -e $pidfile ]; then shutdown-all; fi
+        echo -n "."
+        sleep 0.5
+    done
+    echo " OK"
+}
+startup-concourse-compose
+
+
+###
+# here we takeoff and start to fly
+###
+function fly-stop {
+    log "${FUNCNAME[0]}: killing"
+    fly -t $CONCOURSE_TARGET destroy-pipeline -p $PIPELINE_NAME --non-interactive
+}
+function fly-sync { 
+    log "${FUNCNAME[0]}: logging into concourse at $CONCOURSE_URL"
+    fly -t $CONCOURSE_TARGET login --insecure -u nsx -p vmware --concourse-url $CONCOURSE_URL -n main
+    fly -t $CONCOURSE_TARGET sync
+}
+fly-sync
+
+function fly-reset {
+    log "${FUNCNAME[0]}: setting the NSX-t install pipeline $PIPELINE_NAME"
+    fly -t $CONCOURSE_TARGET set-pipeline -p $PIPELINE_NAME -c ${pipeline_dir}/pipelines/nsx-t-install.yml -l ${BIND_MOUNT_DIR}/${pipeline_internal_config} -l ${BIND_MOUNT_DIR}/${CONFIG_FILE_NAME} --non-interactive
+}
+fly-reset
+
+function fly-start {
+    log "${FUNCNAME[0]}: unpausing the pipepline $PIPELINE_NAME"
+    fly -t $CONCOURSE_TARGET unpause-pipeline -p $PIPELINE_NAME
+}
+fly-start
+function fly-status {
+    fly targets
+    fly -t $CONCOURSE_TARGET status
+    fly -t $CONCOURSE_TARGET workers
+    fly -t $CONCOURSE_TARGET pipelines
+}
+
+set +a
+
+log "${FUNCNAME[0]}: adding various fly-functions to bashrc"
+declare -f log fly-stop fly-sync fly-reset fly-start fly-status >> ~/.bashrc
+
+log "${FUNCNAME[0]}: should all be ready at =====>>> ${CONCOURSE_URL} <<<====="
+
+
+###
+# going interactive or down
+###
+
+if [ -t 0 ] ; then
+    log "${FUNCNAME[0]}: (interactive shell - use 'shutdown-all' to exit)"
+    echo "(note: use 'fly-stop ; fly-reset ; fly-start' to re-read the yaml file)"
+    bash --login
+    log "${FUNCNAME[0]}: (interactive shell - terminated with $?)"
 else
-        sed -i "0,/^ *- HTTP_PROXY/ s|HTTP_PROXY.*$|HTTP_PROXY=${HTTP_PROXY}|" docker-compose.yml
-        sed -i "0,/^ *- http_proxy_url/ s|http_proxy_url.*$|http_proxy_url=${HTTP_PROXY}|" docker-compose.yml
-
-        sed -i "0,/^ *- HTTPS_PROXY/ s|HTTPS_PROXY.*$|HTTPS_PROXY=${HTTPS_PROXY}|" docker-compose.yml
-        sed -i "0,/^ *- https_proxy_url/ s|https_proxy_url.*$|https_proxy_url=${HTTPS_PROXY}|" docker-compose.yml
-
-        sed -i "0,/^ *- NO_PROXY/ s|NO_PROXY.*$|NO_PROXY=${NO_PROXY}|" docker-compose.yml
-        sed -i "0,/^ *- no_proxy/ s|no_proxy.*$|no_proxy=${NO_PROXY}|" docker-compose.yml
+    log "${FUNCNAME[0]}: (headless mode - remove '$pidfile' to terminate)"
+    while [ -e $pidfile ]; do # checking-for-pid-existence-idle-loop
+        sleep 1
+        # if ! docker ps | grep -q concourse-worker; then log "${FUNCNAME[0]}: lost worker, not good"; break; fi
+    done
+    log "${FUNCNAME[0]}: (headless mode - pidfile was removed)"
+    shutdown-all
 fi
-#sed -i "0,/^ *- CONCOURSE_GARDEN_NETWORK/ s|- CONCOURSE_GARDEN_NETWORK.*$|#- CONCOURSE_GARDEN_NETWORK|" docker-compose.yml
-#sed -i "/^ *- CONCOURSE_EXTERNAL_URL/ a\    - CONCOURSE_NO_REALLY_I_DONT_WANT_ANY_AUTH=true" docker-compose.yml
 
-echo "bringing up Concourse server in a docker-compose cluster"
-docker-compose up -d
-
-# waiting for the concourse API server to start up
-while true; do
-	curl -s -o /dev/null $CONCOURSE_URL
-	if [[ $? -eq 0 ]]; then
-		break
-	fi
-	echo "waiting for Concourse web server to be running"
-	sleep 2
-done
-echo "brought up the Concourse cluster"
-
-# using fly to start the pipeline
-CONCOURSE_TARGET=nsx-concourse
-PIPELINE_NAME=nsx-t-install
-echo "logging into concourse at $CONCOURSE_URL"
-fly -t $CONCOURSE_TARGET sync
-fly --target $CONCOURSE_TARGET login -u nsx -p vmware --concourse-url $CONCOURSE_URL -n main
-echo "setting the NSX-t install pipeline $PIPELINE_NAME"
-fly_reset_cmd="fly -t $CONCOURSE_TARGET set-pipeline -p $PIPELINE_NAME -c ${pipeline_dir}/pipelines/nsx-t-install.yml -l ${BIND_MOUNT_DIR}/${pipeline_internal_config} -l ${BIND_MOUNT_DIR}/${CONFIG_FILE_NAME}"
-yes | $fly_reset_cmd
-echo "unpausing the pipepline $PIPELINE_NAME"
-fly -t $CONCOURSE_TARGET unpause-pipeline -p $PIPELINE_NAME
-
-# add an alias for set-pipeline command
-echo "alias fly-reset=\"$fly_reset_cmd\"" >> ~/.bashrc
-destroy_cmd="cd $BIND_MOUNT_DIR; fly -t $CONCOURSE_TARGET destroy-pipeline -p $PIPELINE_NAME; docker-compose down; docker stop nginx-server; docker rm nginx-server;"
-echo "alias destroy=\"$destroy_cmd\"" >> ~/.bashrc
-source ~/.bashrc
-
-while true; do
-	is_worker_running=$(docker ps | grep concourse-worker)
-	if [[ ! $is_worker_running ]]; then
-		docker-compose restart concourse-worker
-		echo "concourse worker is down; restarted it"
-		break
-	fi
-	sleep 5
-done
-
-sleep 3d
-fly -t $CONCOURSE_TARGET destroy-pipeline -p $PIPELINE_NAME
-docker-compose down
-docker stop nginx-server
-docker rm nginx-server
-exit 0
+if [ -e $pidfile ]; then shutdown-all; fi


### PR DESCRIPTION
All tough I still don't get why `fly sync` can work before `fly login`, the current image only seems to work on ubuntu hosts. Following up issue #18 and the canceled pr #19, the attached proposal is an overhaul of the current build and run methods.

Essentially:
_run.sh_
- the ENTRYPOINT directive allows for container parameters to be passed into the actual application (note: this behavior differs from CMD directive). The proposed `run.sh` allows for argument segregation of docker related and application related arguments. Please find a sample in the simplified `run.nsx-t-install-er.sh` script.
- in short: argument passing has changed into what docker requires and what run.sh requires.
- the original flow has been kept, but 'modularized' into shell functions. 
- the fly-related commands have also been rewritten into shell-functions.
- the container (should) automatically detect if it's interactive and present you with a bash.
- shutdown and destruction has been refactored.
- the involved containers should not stay around and cause conflict (using `--rm` switch and ensuring `docker-compose down` was called upon graceful container termination)

_Dockerfile_
- splitup into multiple `run` statements leverageing the layering during the build.
- unified downloads to wget and added some documentation.

_run.nsx-t-install-er.sh_
- helper to figure your IP and DNS automagically.

So far i was able to bring the concourse pipeline for nsx-t-install up and running on a Fedora host.
cheers

[proposed](https://github.com/maldex/nsx-t-datacenter-ci-pipelines/blob/master/docker_image/run.sh) vs [recent](https://github.com/vmware/nsx-t-datacenter-ci-pipelines/blob/master/docker_image/run.sh)
Signed-off-by: Maldex <godlike@gmx.ch>