### PR TITLE
Apply license before add edge vm as transport node

### DIFF
--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -248,6 +248,19 @@
         state: present
       register: vtep_pool_object
 
+    - name: Apply license
+      uri:
+        url: "https://{{ hostvars['localhost'].nsx_manager_ip }}/api/v1/licenses"
+        method: POST
+        validate_certs: no
+        force_basic_auth: yes
+        user: "{{hostvars['localhost'].nsx_manager_username}}"
+        password: "{{hostvars['localhost'].nsx_manager_password}}"
+        body_format: json
+        body:
+          license_key: "{{license_key}}"
+        status_code: 200
+
     - name: Add Edge VM as transport node
       nsxt_transport_nodes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"

--- a/nsxt_yaml/vars.yml
+++ b/nsxt_yaml/vars.yml
@@ -5,6 +5,8 @@ overlay_host_switch: "hostswitch-overlay"
 vlan_transport_zone: 'vlan-tz'
 vlan_host_switch: "hostswitch-vlan"
 
+license_key: "M40VJ-DT34J-381C1-0A222-0NPN7"
+
 transportzones:
 - display_name: "{{overlay_transport_zone}}"
   transport_type: "OVERLAY"


### PR DESCRIPTION
When deploy nsx-T grindcore, it needs license before
adding edge vm as transport node