### PR TITLE
In nsx-t G build, days_valid param is required for

### DIFF
--- a/tasks/config-nsx-t-extras/nsx_t_gen.py
+++ b/tasks/config-nsx-t-extras/nsx_t_gen.py
@@ -616,7 +616,12 @@ def generate_self_signed_cert(common_name, csr_request):
     csr_id = resp.json()['id']
 
     self_sign_cert_api_endpint = TRUST_MGMT_SELF_SIGN_CERT
-    self_sign_cert_url = '%s%s%s' % (self_sign_cert_api_endpint, csr_id, '?action=self_sign')
+    days_valid = os.getenv('self_sign_cert_days_valid_int', '').strip()
+    if not days_valid or days_valid == '' or days_valid == 'null':
+        days_valid = '3650'
+    self_sign_cert_url = ('%s%s?action=self_sign&&days_valid=%s' %
+                         (self_sign_cert_api_endpint, csr_id,
+                          days_valid))
     self_sign_csr_response = client.post(self_sign_cert_url, '').json()
     print('CSR Request posted with response %s' % self_sign_csr_response)
     return self_sign_csr_response['id']


### PR DESCRIPTION
self sign CSR request