### PR TITLE
Change nsxt_transport_nodes to add edge as transport node

### DIFF
--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -288,6 +288,7 @@
               ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{overlay_transport_zone}}"
+              transport_zone_name: "{{vlan_transport_zone}}"
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
@@ -296,8 +297,12 @@
             pnics:
             - device_name: fp-eth1
               uplink_name: "{{uplink_1_name}}"
+            ip_assignment_spec:
+              resource_type: StaticIpPoolSpec
+              ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{vlan_transport_zone}}"
+              transport_zone_name: "{{overlay_transport_zone}}"
         node_deployment_info:
           resource_type: "EdgeNode"
           display_name: "{{hostvars[item].hostname}}"


### PR DESCRIPTION
Due to the nsxt api and ansible module changes for new NSXT
build, we need to adapt to add edge as transport node

This is tested with NSXT RTQA#26 build.
Signed-off-by: XiaoPei Liu<lxiaopei@vmware.com>