### PR TITLE
Change args for calling Impactor creating TZ and TN API

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ The above command will automatically download the ovftool (e.g. VMware-ovftool-4
 ---
 __If running the pipeline on existing concourse environment and not using the nsx-t-install image, please perform following additional steps:__ in nsx_pipeline_config.yml that was created under /home/concourse, add the following two lines at the beginning, depending on which NSX-T version you are deploying:
 
-| NSX-T 2.3.0 & earlier  |   NSX-T 2.4.0   |  NSX-T 2.5.0  |
-|:----------------------:|:---------------:|:-------------:|
-| nsxt_ansible_branch=v1.0.0 |  nsxt_ansible_branch=master | nsxt_ansible_branch=dev |
-| nsx_t_pipeline_branch=nsxt_2.3.0 |  nsxt_ansible_branch=nsxt_2.4.0 | nsx_t_pipeline_branch=master |
+| NSX-T 2.3.0 & earlier  |   NSX-T 2.4.0   |  NSX-T 2.5.0  |  NSX-T 3.0.0 - 3.1.3 |  NSX-T 3.2.0  |
+|:----------------------:|:---------------:|:-------------:|:-------------:|:-------------:|
+| nsxt_ansible_branch=v1.0.0 |  nsxt_ansible_branch=master | nsxt_ansible_branch=dev |nsxt_ansible_branch=v3.0.0 |nsxt_ansible_branch=v3.0.0
+| nsx_t_pipeline_branch=nsxt_2.3.0 |  nsx_t_pipeline_branch=nsxt_2.4.0 | nsx_t_pipeline_branch=master |nsx_t_pipeline_branch=nsxt_3.0.0 | nsx_t_pipeline_branch=nsxt_3.2.0
 
 Also, if ovftool and ova files were downloaded manually, add ``ova_file_name=<ova_file_name>`` and ``ovftool_file_name=<ovftool_file_name>`` in nsx_pipeline_config.yml as well.
 Ignore this if you are using the docker image provided in this repository.

--- a/nsxt_yaml/basic_resources.yml
+++ b/nsxt_yaml/basic_resources.yml
@@ -95,8 +95,6 @@
           - host_switch_profiles:
             - name: "{{item}}-profile"
               type: UplinkHostSwitchProfile
-            host_switch_name: "{{overlay_host_switch}}"
-            host_switch_mode: "STANDARD"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
@@ -149,13 +147,12 @@
           - host_switch_profiles:
             - name: "{{host_uplink_prof}}"
               type: UplinkHostSwitchProfile
-            host_switch_name: "{{overlay_host_switch}}"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
               ip_pool_name: "{{vtep_ip_pool_name}}"
-        transport_zone_endpoints:
-        - transport_zone_name: "{{overlay_transport_zone}}"
+            transport_zone_endpoints:
+            - transport_zone_name: "{{overlay_transport_zone}}"
         node_deployment_info:
           resource_type: "HostNode"
           display_name: "{{hostvars[item].fabric_node_name}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -217,7 +217,6 @@
         display_name: "{{item.display_name}}"
         description: "NSX {{item.transport_type}} Transport Zone"
         transport_type: "{{item.transport_type}}"
-        host_switch_name: "{{item.host_switch_name}}"
         state: "present"
       with_items:
       - "{{transportzones}}"
@@ -280,8 +279,6 @@
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
-            host_switch_mode: STANDARD
-            host_switch_name: "{{overlay_host_switch}}"
             pnics:
             - device_name: fp-eth0
               uplink_name: "{{uplink_1_name}}"
@@ -290,19 +287,6 @@
               ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{overlay_transport_zone}}"
-          - host_switch_profiles:
-            - name: "{{edge_uplink_prof}}"
-              type: UplinkHostSwitchProfile
-            host_switch_mode: STANDARD
-            host_switch_name: "{{vlan_host_switch}}"
-            pnics:
-            - device_name: fp-eth1
-              uplink_name: "{{uplink_1_name}}"
-            ip_assignment_spec:
-              resource_type: StaticIpPoolSpec
-              ip_pool_name: "{{vtep_ip_pool_name}}"
-            transport_zone_endpoints:
-            - transport_zone_name: "{{vlan_transport_zone}}"
         node_deployment_info:
           resource_type: "EdgeNode"
           display_name: "{{hostvars[item].hostname}}"
@@ -320,7 +304,6 @@
               - "{{hostvars[item].vc_overlay_network_for_edge}}"
               - "{{hostvars[item].vc_uplink_network_for_edge}}"
               management_network: "{{hostvars[item].vc_management_network_for_edge}}"
-              hostname: "{{hostvars[item].hostname}}"
               compute: "{{hostvars[item].vc_cluster_for_edge}}"
               storage: "{{hostvars[item].vc_datastore_for_edge}}"
               default_gateway_addresses:
@@ -329,7 +312,9 @@
               - ip_addresses:
                 - "{{hostvars[item].ip}}"
                 prefix_length: "{{hostvars[item].prefix_length}}"
-              enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
+          node_settings:
+            hostname: "{{hostvars[item].hostname}}"
+            enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
         state: present
       with_items:
       - "{{groups['edge_nodes']}}"

--- a/nsxt_yaml/vars.yml
+++ b/nsxt_yaml/vars.yml
@@ -10,10 +10,8 @@ license_key: "M40VJ-DT34J-381C1-0A222-0NPN7"
 transportzones:
 - display_name: "{{overlay_transport_zone}}"
   transport_type: "OVERLAY"
-  host_switch_name: "{{overlay_host_switch}}" # will create one with this name
 - display_name: "{{vlan_transport_zone}}"
   transport_type: "VLAN"
-  host_switch_name: "{{vlan_host_switch}}"
 
 vtep_ip_pool_name: vtep-ip-pool
 

--- a/tasks/install-nsx-t/modify_options.py
+++ b/tasks/install-nsx-t/modify_options.py
@@ -10,7 +10,7 @@ DATA_NETWORKS = "data_networks:"
 MANAGEMENT_NETWORK = "management_network: \"{{hostvars[item]"
 COMPUTE = "compute: \"{{hostvars[item].vc_cluster_for_edge"
 STORAGE = "storage: \"{{hostvars[item].vc_datastore_for_edge"
-
+NODE_SETTINGS = "node_settings"
 
 def add_new_line_if_absent(line):
     if line.endswith('\n'):
@@ -38,16 +38,14 @@ def add_dns_server_option():
                     dns_line = ' ' * leading_spaces + ("dns_server: %s\n"
                                                        % dns_servers_spec.split(',')[0])
                     line = line.replace(line, dns_line)
-                elif PREFIX_LENGTH in line:
-                    leading_spaces = len(line) - len(line.lstrip()) - 2
+                elif NODE_SETTINGS in line:
+                    leading_spaces = len(line) - len(line.lstrip()) + 2
                     dns_line = ' ' * leading_spaces
-                    if ',' not in dns_servers_spec:
-                        dns_line += "dns_servers: [\"{{hostvars['localhost'].dns_server}}\"]"
-                    else:
-                        dns_servers = [s.strip() for s in dns_servers_spec.split(',')]
-                        dns_line += "dns_servers:"
-                        for server in dns_servers:
-                            dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
+
+                    dns_servers = [s.strip() for s in dns_servers_spec.split(',')]
+                    dns_line += "dns_servers:"
+                    for server in dns_servers:
+                        dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
                     line = line.replace(line, line + dns_line)
                 new_file.write(add_new_line_if_absent(line))
     replace_file(abs_path)


### PR DESCRIPTION
The nsx Impactor has APIs changed:
https://confluence.eng.vmware.com/pages/viewpage.action?spaceKey=NSBU&title=APIs+planned+for+removal+in+Impactor

This patch is to change nsx-t deploy yaml for supporting NSXT impactor deployment.
The two changes in Impactor API is creating Transport Zone and Transport node

1. For NSXT impactor has Transport Zone API field deprecation:
POST /api/v1/transport-zones
{
	  "display_name":"tz1",
	  "host_switch_name":"test-host-switch-1", <<==== WILL BE REMOVED
	  "host_switch_mode": "STANDARD", <<==== WILL BE REMOVED
	  "description":"Transport Zone 1",
	  "transport_type":"OVERLAY"
}

So, the NCP NSXT configuration pipeline will do changes as below:
 1).Remove host_switch_name as an argument for creating tz zone
 2).Remove host_switch_mode as an argument for creating tz zone

2.  The NSXT impactor also has Transport Node + Transport Node Profile
API field deprecation:
POST /api/v1/transport-nodes
POST /api/v1/transport-node-profiles
{
"node_id": "92f893b0-1157-4926-9ce3-a1787100426c",
"host_switch_spec": {
"host_switches": [
{
...
...
"transport_zone_endpoints": [ <<<==== SHOULD BE USED INSTEAD
{
"transport_zone_id": "1b3a2f36-bfd1-443e-a0f6-4de01abc963e"
}
],
}
],
"resource_type": "StandardHostSwitchSpec"
},
"transport_zone_endpoints": [], <<<<=== WILL BE REMOVED
"node_deployment_info": {
"deployment_type": "VIRTUAL_MACHINE",
"deployment_config": {
...
"vm_deployment_config": {
"hostname": "edge", <-- will be removed
"data_network_ids": [
"network-24"
],
"search_domains": [ "vmware.com" ] <<<<=== WILL BE REMOVED (replacement in out block)
"dns_servers": [ "10.172.40.1" ], <<<<=== WILL BE REMOVED
"enable_ssh": true, <<<<=== WILL BE REMOVED
"allow_ssh_root_login": true, <<<<=== WILL BE REMOVED
"placement_type": "VsphereDeploymentConfig"
},
...
"node_settings": {
"hostname": "edge", <<<<=== This should be used - REPLACEMENT
"search_domains": ["eng.vmware.com" ], <<<<=== This should be used - REPLACEMENT
"dns_servers": [ "10.195.12.31"], <<<<=== This should be used - REPLACEMENT
"enable_ssh": true, <<<<=== This should be used - REPLACEMENT
"allow_ssh_root_login": true <<<<=== This should be used - REPLACEMENT
},
"resource_type": "EdgeNode",
}
...
}

So, based on the aforementioned API changes, the NCP NSXT configuration
pipeline will do changes as below:
1.Remove hostname as an argument from "vm_deployment_config"
2.Move "transport_zone_endpoints" inside "host_switch_spec": "host_switches"
3.Remove enable_ssh as an argument from  "vm_deployment_config"
4.Add hostname and enable_ssh to a new property: "node_settings"
5.Remove dns_servers from from "vm_deployment_config"
6.Add dns_servers to a new property: "node_settings" by changing
modify_options.py
7.Remove adding dns_servers from "vm_deployment_config" by changing modify_options.py    remove adding dns_server in PREFIX_LENGTH line check
8.Remove one host_switch_profiles linked to vlan_transport_zone to avoide error:
"Multiple HostSwitches were found with the same HostSwitch nsxDefaultHostSwitch in TransportNode"

Signed-off-by: Yun Deng<dengyu@vmware.com>