### PR TITLE
Support NSXT-3.2 Impactor Deployment with ansible-for-nsxt v3.2.0

### DIFF
--- a/nsxt_yaml/basic_resources.yml
+++ b/nsxt_yaml/basic_resources.yml
@@ -31,7 +31,7 @@
         - "{{groups['edge_nodes']}}"
 
     - name: NSX-T Edge Cluster
-      nsxt_edge_clusters:
+      vmware.ansible_for_nsxt.nsxt_edge_clusters:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -44,25 +44,8 @@
 ###############################################################################
 # Configure compute clusters for auto NSX install
 ###############################################################################
-    - name: Enable auto install of NSX for specified clusters
-      nsxt_compute_collection_fabric_templates:
-        hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
-        username: "{{hostvars['localhost'].nsx_manager_username}}"
-        password: "{{hostvars['localhost'].nsx_manager_password}}"
-        validate_certs: False
-        display_name: "{{item}}-fabric_template"
-        compute_manager_name: "{{compute_manager_name}}"
-        cluster_name: "{{item}}"
-        auto_install_nsx: True
-        state: present
-      with_items:
-        - "{{hostvars['localhost'].clusters_to_install_nsx}}"
-      register: auto_install_nsx_result
-      when:
-        - hostvars['localhost'].clusters_to_install_nsx is defined
-
     - name: Create uplink profiles for the clusters to be auto installed
-      nsxt_uplink_profiles:
+      vmware.ansible_for_nsxt.nsxt_uplink_profiles:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -79,10 +62,9 @@
       when:
         - hostvars['localhost'].clusters_to_install_nsx is defined
         - hostvars['localhost'].per_cluster_vlans is defined
-        - auto_install_nsx_result.changed == true
 
     - name: Create transport node profile for cluster
-      nsxt_transport_node_profiles:
+      vmware.ansible_for_nsxt.nsxt_transport_node_profiles:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -95,12 +77,14 @@
           - host_switch_profiles:
             - name: "{{item}}-profile"
               type: UplinkHostSwitchProfile
+            host_switch_name: "{{overlay_host_switch}}"
+            host_switch_mode: "STANDARD"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
               ip_pool_name: "{{vtep_ip_pool_name}}"
-        transport_zone_endpoints:
-        - transport_zone_name: "{{overlay_transport_zone}}"
+            transport_zone_endpoints:
+            - transport_zone_name: "{{overlay_transport_zone}}"
         state: present
       with_items:
         - "{{hostvars['localhost'].clusters_to_install_nsx}}"
@@ -110,7 +94,7 @@
       register: transport_node_profile_result
 
     - name: Create transport node collection for the cluster to enable auto creation of TNs
-      nsxt_transport_node_collections:
+      vmware.ansible_for_nsxt.nsxt_transport_node_collections:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -133,7 +117,7 @@
 # Install NSX on individual ESX hosts, if any
 ###############################################################################
     - name: Create transport nodes for ESX hosts (2.4.0 and later)
-      nsxt_transport_nodes:
+      vmware.ansible_for_nsxt.nsxt_transport_nodes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -147,6 +131,8 @@
           - host_switch_profiles:
             - name: "{{host_uplink_prof}}"
               type: UplinkHostSwitchProfile
+            host_switch_name: "{{overlay_host_switch}}"
+            host_switch_mode: "STANDARD"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
@@ -174,7 +160,7 @@
 # Tier 0 Router
 ###############################################################################
     - name: NSX-T T0 Logical Router
-      nsxt_logical_routers:
+      vmware.ansible_for_nsxt.nsxt_logical_routers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -189,7 +175,7 @@
       register: t0
 
     - name: Add static routes
-      nsxt_logical_router_static_routes:
+      vmware.ansible_for_nsxt.nsxt_logical_router_static_routes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -203,7 +189,7 @@
         state: present
 
     - name: Create VLAN logical switch
-      nsxt_logical_switches:
+      vmware.ansible_for_nsxt.nsxt_logical_switches:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -218,7 +204,7 @@
         - t0.changed == true
 
     - name: Logical Switch Port for uplink_1
-      nsxt_logical_ports:
+      vmware.ansible_for_nsxt.nsxt_logical_ports:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -232,7 +218,7 @@
         - t0.changed == true
 
     - name: Create logical router port for uplink1
-      nsxt_logical_router_ports:
+      vmware.ansible_for_nsxt.nsxt_logical_router_ports:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -255,7 +241,7 @@
         - t0.changed == true
 
     - name: Logical Switch Port for uplink_2
-      nsxt_logical_ports:
+      vmware.ansible_for_nsxt.nsxt_logical_ports:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -270,7 +256,7 @@
         - t0.changed == true
 
     - name: Create logical router port for uplink2
-      nsxt_logical_router_ports:
+      vmware.ansible_for_nsxt.nsxt_logical_router_ports:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -294,7 +280,7 @@
         - t0.changed == true
 
     - name: HA VIP for T0 Router
-      nsxt_logical_routers:
+      vmware.ansible_for_nsxt.nsxt_logical_routers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -6,7 +6,7 @@
     - vars.yml
   tasks:
     - name: deploy NSX Manager OVA
-      nsxt_deploy_ova:
+      vmware.ansible_for_nsxt.nsxt_deploy_ova:
         ovftool_path: "{{ovftool_bin_path}}"
         datacenter: "{{hostvars['localhost'].vcenter_datacenter}}"
         datastore: "{{hostvars['localhost'].vcenter_datastore}}"
@@ -34,7 +34,7 @@
       register: ova_deploy_status
 
     - name: Check manager status
-      nsxt_manager_status:
+      vmware.ansible_for_nsxt.nsxt_manager_status:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -58,7 +58,7 @@
       shell: "last=1; while [ $last -ne 0 ]; do curl -s -o /dev/null -ku '{{hostvars['localhost'].nsx_manager_username}}:{{hostvars['localhost'].nsx_manager_password}}' https://{{hostvars['localhost'].nsx_manager_ip}}/api/v1/trust-management/certificates --connect-timeout 5; last=$?; echo \"waiting for NSX Manager to come up\"; done"
 
     - name: Add license for NSX-T manager if applicable
-      nsxt_licenses:
+      vmware.ansible_for_nsxt.nsxt_licenses:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -107,7 +107,7 @@
       pause: minutes=2
 
     - name: Deploy compute manager
-      nsxt_fabric_compute_managers:
+      vmware.ansible_for_nsxt.nsxt_fabric_compute_managers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -127,7 +127,7 @@
 
     # TODO: change var names
     - name: Deploy compute manager 2
-      nsxt_fabric_compute_managers:
+      vmware.ansible_for_nsxt.nsxt_fabric_compute_managers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -167,7 +167,7 @@
         - hostvars['localhost'].resource_reservation_off == "true"
 
     - name: Deploy additional controller-managers
-      nsxt_manager_auto_deployment:
+      vmware.ansible_for_nsxt.nsxt_manager_auto_deployment:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -208,7 +208,7 @@
 
       # TODO: does not support tag
     - name: Create Transport Zones
-      nsxt_transport_zones:
+      vmware.ansible_for_nsxt.nsxt_transport_zones:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -222,7 +222,7 @@
       - "{{transportzones}}"
 
     - name: Create uplink profile
-      nsxt_uplink_profiles:
+      vmware.ansible_for_nsxt.nsxt_uplink_profiles:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -238,7 +238,7 @@
 
       # # TODO: support tags
     - name: Create VTEP IP pool
-      nsxt_ip_pools:
+      vmware.ansible_for_nsxt.nsxt_ip_pools:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -267,7 +267,7 @@
         status_code: 200
 
     - name: Add Edge VM as transport node
-      nsxt_transport_nodes:
+      vmware.ansible_for_nsxt.nsxt_transport_nodes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -279,6 +279,8 @@
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
+            host_switch_mode: STANDARD
+            host_switch_name: "{{overlay_host_switch}}"
             pnics:
             - device_name: fp-eth0
               uplink_name: "{{uplink_1_name}}"
@@ -287,6 +289,19 @@
               ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{overlay_transport_zone}}"
+          - host_switch_profiles:
+            - name: "{{edge_uplink_prof}}"
+              type: UplinkHostSwitchProfile
+            host_switch_mode: STANDARD
+            host_switch_name: "{{vlan_host_switch}}"
+            pnics:
+            - device_name: fp-eth1
+              uplink_name: "{{uplink_1_name}}"
+            ip_assignment_spec:
+              resource_type: StaticIpPoolSpec
+              ip_pool_name: "{{vtep_ip_pool_name}}"
+            transport_zone_endpoints:
+            - transport_zone_name: "{{vlan_transport_zone}}"
         node_deployment_info:
           resource_type: "EdgeNode"
           display_name: "{{hostvars[item].hostname}}"

--- a/tasks/install-nsx-t/nsxt-ansible-requirements.yml
+++ b/tasks/install-nsx-t/nsxt-ansible-requirements.yml
@@ -1,0 +1,6 @@
+---
+# requirements.yml
+collections:
+  - name: ansible-for-nsxt
+    type: git
+    source: https://github.com/vmware/ansible-for-nsxt.git,v3.2.0

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -66,12 +66,20 @@ if [ "$enable_ansible_debug_int" == "true" ]; then
   DEBUG="-vvv"
 fi
 
+echo "Install Ansible NSXT v3.2.0 Galaxy collection"
+#ansible-galaxy collection install git+https://github.com/vmware/ansible-for-nsxt.git,v3.2.0
+cp ${PIPELINE_DIR}/tasks/install-nsx-t/nsxt-ansible-requirements.yml ./
+ansible-galaxy collection install -r ./nsxt-ansible-requirements.yml
+
 create_hosts
 cp ${PIPELINE_DIR}/tasks/install-nsx-t/get_mo_ref_id.py ./
 python get_mo_ref_id.py --host $vcenter_ip_int --user $vcenter_username_int --password $vcenter_password_int
 
 cp hosts.out ${PIPELINE_DIR}/nsxt_yaml/basic_topology.yml ${PIPELINE_DIR}/nsxt_yaml/vars.yml nsxt-ansible/
 cd nsxt-ansible
+echo "cd nsxt-ansible"
+ls
+
 cp ${PIPELINE_DIR}/tasks/install-nsx-t/modify_options.py ./
 
 if [[ "$unified_appliance_int" == "true" ]]; then

--- a/tasks/install-nsx-t/task.yml
+++ b/tasks/install-nsx-t/task.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
-    tag: py3
+    tag: ubuntu18
 
 inputs:
   - name: nsx-t-gen-pipeline

--- a/tasks/uninstall-nsx-t/task.yml
+++ b/tasks/uninstall-nsx-t/task.yml
@@ -6,17 +6,17 @@ image_resource:
   type: docker-image
   source:
     repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
-    tag: py3
-  
+    tag: ubuntu18
+
 # params:
 #   VCENTER_HOST:
 #   VCENTER_USR:
 #   VCENTER_PWD:
 
-    
+
 inputs:
   - name: nsx-t-gen-pipeline
-  
+
 run:
   path: nsx-t-gen-pipeline/tasks/uninstall-nsx-t/task.sh
 


### PR DESCRIPTION
This patch is to make changes to support NSXT-3.2 impactor deployment with ansible-for-nsxt v3.2.0.
The following changes have been done:
1. Add support to deploy NSXT impactor with ansible-for-nsxt v3.2.0
https://github.com/vmware/ansible-for-nsxt/tree/v3.2.0
2. Update nsx-t-gen-worker docker image:
   nsx-t-gen-worker is upgraded to ubuntu18.4 with default python3 is python3.6.
   ansbile in nsx-t-gen-worker is upgraded to 2.11.10 since ansible-for-nsxt v3.2.0 is using Ansible Galaxy collection
   to install ansible-for-nsxt modules that needs ansbile>=2.10.0.
3. Remove nsxt_compute_collection_fabric_templates module since it is not supported any longer in ansible nsxt v3.2.0
3. Fix https://github.com/vmware/nsx-t-datacenter-ci-pipelines/pull/92 deployment error for manger testbed:
   1).Add back the removed host_switch_profiles linked to vlan_transport_zone, without vlan_transport_zone the transport nodes can not access external traffic
   2).Add host_switch_name and host_switch_mode to "host_switch_spec" when creating transport-nodes or transport-node-profile
   otherwise, in the context of Edge node VM creation, it's needed to create two host_switch_profiles，
   one for overlay_host_switch in overlay_transport_zone, and one for vlan_host_switch in vlan_transport_zone.
   Hence, host_switch_name will be used to distinguish host switch on two transport zones.