### PR TITLE
Upgrade nsxt configure concourse docker image

### DIFF
--- a/tasks/install-nsx-t/task.yml
+++ b/tasks/install-nsx-t/task.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
-    tag: ubuntu18
+    tag: ubuntu18-v1
 
 inputs:
   - name: nsx-t-gen-pipeline

--- a/tasks/uninstall-nsx-t/task.yml
+++ b/tasks/uninstall-nsx-t/task.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
-    tag: ubuntu18
+    tag: ubuntu18-v1
 
 # params:
 #   VCENTER_HOST:


### PR DESCRIPTION
NSXT installation, configuration docker image:
projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker

Upgrade Ansible module from python2.7 to python3.6
Set docker image tag ubuntu18-v1