### PR TITLE
Fix datastore name change of deployed cluster1 in VCenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ The above command will automatically download the ovftool (e.g. VMware-ovftool-4
 ---
 __If running the pipeline on existing concourse environment and not using the nsx-t-install image, please perform following additional steps:__ in nsx_pipeline_config.yml that was created under /home/concourse, add the following two lines at the beginning, depending on which NSX-T version you are deploying:
 
-| NSX-T 2.3.0 & earlier  |   NSX-T 2.4.0   |  NSX-T 2.5.0  |
-|:----------------------:|:---------------:|:-------------:|
-| nsxt_ansible_branch=v1.0.0 |  nsxt_ansible_branch=master | nsxt_ansible_branch=dev |
-| nsx_t_pipeline_branch=nsxt_2.3.0 |  nsxt_ansible_branch=nsxt_2.4.0 | nsx_t_pipeline_branch=master |
+| NSX-T 2.3.0 & earlier  |   NSX-T 2.4.0   |  NSX-T 2.5.0  |  NSX-T 3.0.0 - 3.1.3 |  NSX-T 3.2.0  |
+|:----------------------:|:---------------:|:-------------:|:-------------:|:-------------:|
+| nsxt_ansible_branch=v1.0.0 |  nsxt_ansible_branch=master | nsxt_ansible_branch=dev |nsxt_ansible_branch=v3.0.0 |nsxt_ansible_branch=v3.0.0
+| nsx_t_pipeline_branch=nsxt_2.3.0 |  nsx_t_pipeline_branch=nsxt_2.4.0 | nsx_t_pipeline_branch=master |nsx_t_pipeline_branch=nsxt_3.0.0 | nsx_t_pipeline_branch=nsxt_3.2.0
 
 Also, if ovftool and ova files were downloaded manually, add ``ova_file_name=<ova_file_name>`` and ``ovftool_file_name=<ovftool_file_name>`` in nsx_pipeline_config.yml as well.
 Ignore this if you are using the docker image provided in this repository.

--- a/functions/create_hosts.sh
+++ b/functions/create_hosts.sh
@@ -170,6 +170,7 @@ tier0_uplink_port_subnet="$tier0_uplink_port_subnet_int"
 tier0_uplink_next_hop_ip="$tier0_uplink_next_hop_ip_int"
 
 resource_reservation_off="$resource_reservation_off_int"
+appliance_ready_wait="$appliance_ready_wait_int"
 nsx_manager_ssh_enabled="$nsx_manager_ssh_enabled_int"
 unified_appliance="$unified_appliance_int"
 EOF

--- a/functions/create_hosts.sh
+++ b/functions/create_hosts.sh
@@ -144,6 +144,7 @@ mgmt_portgroup="$mgmt_portgroup_int"
 
 vc_datacenter_for_deployment="$vcenter_datacenter_int"
 vc_cluster_for_deployment="$vcenter_cluster_int"
+vc_datastore_for_nsx="$vcenter_datastore_int"
 vc_datastore_for_deployment="$vcenter_datastore_int"
 vc_management_network_for_deployment="$mgmt_portgroup_int"
 

--- a/functions/set_default_params.py
+++ b/functions/set_default_params.py
@@ -15,6 +15,7 @@ def add_default_params_if_necessary():
         'nsx_license_key': '',
         'nsx_manager_root_pwd': 'Admin!23Admin',
         'nsx_manager_cli_pwd': 'Admin!23Admin',
+        'appliance_ready_wait': '2',
         'compute_manager_username': 'Administrator@vsphere.local',
         'compute_manager_password': 'Admin!23',
         'compute_manager_2_vcenter_ip': '',

--- a/nsxt_yaml/basic_resources.yml
+++ b/nsxt_yaml/basic_resources.yml
@@ -95,8 +95,6 @@
           - host_switch_profiles:
             - name: "{{item}}-profile"
               type: UplinkHostSwitchProfile
-            host_switch_name: "{{overlay_host_switch}}"
-            host_switch_mode: "STANDARD"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
@@ -149,13 +147,12 @@
           - host_switch_profiles:
             - name: "{{host_uplink_prof}}"
               type: UplinkHostSwitchProfile
-            host_switch_name: "{{overlay_host_switch}}"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
               ip_pool_name: "{{vtep_ip_pool_name}}"
-        transport_zone_endpoints:
-        - transport_zone_name: "{{overlay_transport_zone}}"
+            transport_zone_endpoints:
+            - transport_zone_name: "{{overlay_transport_zone}}"
         node_deployment_info:
           resource_type: "HostNode"
           display_name: "{{hostvars[item].fabric_node_name}}"

--- a/nsxt_yaml/basic_resources.yml
+++ b/nsxt_yaml/basic_resources.yml
@@ -31,7 +31,7 @@
         - "{{groups['edge_nodes']}}"
 
     - name: NSX-T Edge Cluster
-      nsxt_edge_clusters:
+      vmware.ansible_for_nsxt.nsxt_edge_clusters:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -44,25 +44,8 @@
 ###############################################################################
 # Configure compute clusters for auto NSX install
 ###############################################################################
-    - name: Enable auto install of NSX for specified clusters
-      nsxt_compute_collection_fabric_templates:
-        hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
-        username: "{{hostvars['localhost'].nsx_manager_username}}"
-        password: "{{hostvars['localhost'].nsx_manager_password}}"
-        validate_certs: False
-        display_name: "{{item}}-fabric_template"
-        compute_manager_name: "{{compute_manager_name}}"
-        cluster_name: "{{item}}"
-        auto_install_nsx: True
-        state: present
-      with_items:
-        - "{{hostvars['localhost'].clusters_to_install_nsx}}"
-      register: auto_install_nsx_result
-      when:
-        - hostvars['localhost'].clusters_to_install_nsx is defined
-
     - name: Create uplink profiles for the clusters to be auto installed
-      nsxt_uplink_profiles:
+      vmware.ansible_for_nsxt.nsxt_uplink_profiles:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -79,10 +62,9 @@
       when:
         - hostvars['localhost'].clusters_to_install_nsx is defined
         - hostvars['localhost'].per_cluster_vlans is defined
-        - auto_install_nsx_result.changed == true
 
     - name: Create transport node profile for cluster
-      nsxt_transport_node_profiles:
+      vmware.ansible_for_nsxt.nsxt_transport_node_profiles:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -95,12 +77,14 @@
           - host_switch_profiles:
             - name: "{{item}}-profile"
               type: UplinkHostSwitchProfile
+            host_switch_name: "{{overlay_host_switch}}"
+            host_switch_mode: "STANDARD"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
               ip_pool_name: "{{vtep_ip_pool_name}}"
-        transport_zone_endpoints:
-        - transport_zone_name: "{{overlay_transport_zone}}"
+            transport_zone_endpoints:
+            - transport_zone_name: "{{overlay_transport_zone}}"
         state: present
       with_items:
         - "{{hostvars['localhost'].clusters_to_install_nsx}}"
@@ -110,7 +94,7 @@
       register: transport_node_profile_result
 
     - name: Create transport node collection for the cluster to enable auto creation of TNs
-      nsxt_transport_node_collections:
+      vmware.ansible_for_nsxt.nsxt_transport_node_collections:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -133,7 +117,7 @@
 # Install NSX on individual ESX hosts, if any
 ###############################################################################
     - name: Create transport nodes for ESX hosts (2.4.0 and later)
-      nsxt_transport_nodes:
+      vmware.ansible_for_nsxt.nsxt_transport_nodes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -147,6 +131,8 @@
           - host_switch_profiles:
             - name: "{{host_uplink_prof}}"
               type: UplinkHostSwitchProfile
+            host_switch_name: "{{overlay_host_switch}}"
+            host_switch_mode: "STANDARD"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
@@ -174,7 +160,7 @@
 # Tier 0 Router
 ###############################################################################
     - name: NSX-T T0 Logical Router
-      nsxt_logical_routers:
+      vmware.ansible_for_nsxt.nsxt_logical_routers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -189,7 +175,7 @@
       register: t0
 
     - name: Add static routes
-      nsxt_logical_router_static_routes:
+      vmware.ansible_for_nsxt.nsxt_logical_router_static_routes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -203,7 +189,7 @@
         state: present
 
     - name: Create VLAN logical switch
-      nsxt_logical_switches:
+      vmware.ansible_for_nsxt.nsxt_logical_switches:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -218,7 +204,7 @@
         - t0.changed == true
 
     - name: Logical Switch Port for uplink_1
-      nsxt_logical_ports:
+      vmware.ansible_for_nsxt.nsxt_logical_ports:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -232,7 +218,7 @@
         - t0.changed == true
 
     - name: Create logical router port for uplink1
-      nsxt_logical_router_ports:
+      vmware.ansible_for_nsxt.nsxt_logical_router_ports:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -255,7 +241,7 @@
         - t0.changed == true
 
     - name: Logical Switch Port for uplink_2
-      nsxt_logical_ports:
+      vmware.ansible_for_nsxt.nsxt_logical_ports:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -270,7 +256,7 @@
         - t0.changed == true
 
     - name: Create logical router port for uplink2
-      nsxt_logical_router_ports:
+      vmware.ansible_for_nsxt.nsxt_logical_router_ports:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -294,7 +280,7 @@
         - t0.changed == true
 
     - name: HA VIP for T0 Router
-      nsxt_logical_routers:
+      vmware.ansible_for_nsxt.nsxt_logical_routers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"

--- a/nsxt_yaml/basic_resources.yml
+++ b/nsxt_yaml/basic_resources.yml
@@ -179,6 +179,7 @@
         password: "{{hostvars['localhost'].nsx_manager_password}}"
         validate_certs: False
         logical_router_name: "{{hostvars['localhost'].tier0_router_name}}"
+        display_name: "tier0 static route"
         next_hops:
         - administrative_distance: '1'
           ip_address: "{{hostvars['localhost'].tier0_uplink_next_hop_ip}}"

--- a/nsxt_yaml/basic_resources.yml
+++ b/nsxt_yaml/basic_resources.yml
@@ -81,16 +81,14 @@
         - hostvars['localhost'].per_cluster_vlans is defined
         - auto_install_nsx_result.changed == true
 
-    - name: Enable auto creation of transport nodes for specified clusters
-      nsxt_compute_collection_transport_templates:
+    - name: Create transport node profile for cluster
+      nsxt_transport_node_profiles:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
         validate_certs: False
-        display_name: "{{item}}-transport_template"
-        compute_collections:
-        - compute_manager_name: "{{compute_manager_name}}"
-          cluster_name: "{{item}}"
+        display_name: "{{item}}-transport_node_profile"
+        resource_type: "TransportNodeProfile"
         host_switch_spec:
           resource_type: StandardHostSwitchSpec
           host_switches:
@@ -98,6 +96,7 @@
             - name: "{{item}}-profile"
               type: UplinkHostSwitchProfile
             host_switch_name: "{{overlay_host_switch}}"
+            host_switch_mode: "STANDARD"
             pnics: "{{pnic_list}}"
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
@@ -110,7 +109,27 @@
       when:
         - hostvars['localhost'].clusters_to_install_nsx is defined
         - hostvars['localhost'].per_cluster_vlans is defined
-        - auto_install_nsx_result.changed == true
+      register: transport_node_profile_result
+
+    - name: Create transport node collection for the cluster to enable auto creation of TNs
+      nsxt_transport_node_collections:
+        hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
+        username: "{{hostvars['localhost'].nsx_manager_username}}"
+        password: "{{hostvars['localhost'].nsx_manager_password}}"
+        validate_certs: False
+        display_name: "{{item}}-transport_node_collection"
+        description: Transport node collection
+        resource_type: "TransportNodeCollection"
+        compute_manager_name: "{{compute_manager_name}}"
+        cluster_name: "{{item}}"
+        transport_node_profile_name: "{{item}}-transport_node_profile"
+        state: present
+      with_items:
+      - "{{hostvars['localhost'].clusters_to_install_nsx}}"
+      when:
+      - hostvars['localhost'].clusters_to_install_nsx is defined
+      - hostvars['localhost'].per_cluster_vlans is defined
+      - transport_node_profile_result.changed == true
 
 ###############################################################################
 # Install NSX on individual ESX hosts, if any

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -217,7 +217,6 @@
         display_name: "{{item.display_name}}"
         description: "NSX {{item.transport_type}} Transport Zone"
         transport_type: "{{item.transport_type}}"
-        host_switch_name: "{{item.host_switch_name}}"
         state: "present"
       with_items:
       - "{{transportzones}}"
@@ -280,8 +279,6 @@
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
-            host_switch_mode: STANDARD
-            host_switch_name: "{{overlay_host_switch}}"
             pnics:
             - device_name: fp-eth0
               uplink_name: "{{uplink_1_name}}"
@@ -290,19 +287,6 @@
               ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{overlay_transport_zone}}"
-          - host_switch_profiles:
-            - name: "{{edge_uplink_prof}}"
-              type: UplinkHostSwitchProfile
-            host_switch_mode: STANDARD
-            host_switch_name: "{{vlan_host_switch}}"
-            pnics:
-            - device_name: fp-eth1
-              uplink_name: "{{uplink_1_name}}"
-            ip_assignment_spec:
-              resource_type: StaticIpPoolSpec
-              ip_pool_name: "{{vtep_ip_pool_name}}"
-            transport_zone_endpoints:
-            - transport_zone_name: "{{vlan_transport_zone}}"
         node_deployment_info:
           resource_type: "EdgeNode"
           display_name: "{{hostvars[item].hostname}}"
@@ -320,7 +304,6 @@
               - "{{hostvars[item].vc_overlay_network_for_edge}}"
               - "{{hostvars[item].vc_uplink_network_for_edge}}"
               management_network: "{{hostvars[item].vc_management_network_for_edge}}"
-              hostname: "{{hostvars[item].hostname}}"
               compute: "{{hostvars[item].vc_cluster_for_edge}}"
               storage: "{{hostvars[item].vc_datastore_for_edge}}"
               default_gateway_addresses:
@@ -329,7 +312,9 @@
               - ip_addresses:
                 - "{{hostvars[item].ip}}"
                 prefix_length: "{{hostvars[item].prefix_length}}"
-              enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
+          node_settings:
+            hostname: "{{hostvars[item].hostname}}"
+            enable_ssh: "{{hostvars['localhost'].nsx_manager_ssh_enabled}}"
         state: present
       with_items:
       - "{{groups['edge_nodes']}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -200,6 +200,10 @@
       with_items: "{{groups['controllers']}}"
       when: groups['controllers'] is defined
 
+    - name: Wait for NSX appliances to be status up
+      pause:
+        minutes: "{{hostvars['localhost'].appliance_ready_wait}}"
+
       # TODO: does not support tag
     - name: Create Transport Zones
       nsxt_transport_zones:

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -288,6 +288,7 @@
               ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{overlay_transport_zone}}"
+              transport_zone_name: "{{vlan_transport_zone}}"
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
@@ -296,8 +297,12 @@
             pnics:
             - device_name: fp-eth1
               uplink_name: "{{uplink_1_name}}"
+            ip_assignment_spec:
+              resource_type: StaticIpPoolSpec
+              ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{vlan_transport_zone}}"
+              transport_zone_name: "{{overlay_transport_zone}}"
         node_deployment_info:
           resource_type: "EdgeNode"
           display_name: "{{hostvars[item].hostname}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -179,10 +179,10 @@
           deployment_config:
             placement_type: VsphereClusterNodeVMDeploymentConfig
             vc_name: "{{compute_manager_name}}"
-            management_network_id: "{{hostvars['localhost'].vc_management_network_for_deployment}}"
+            management_network: "{{hostvars['localhost'].vc_management_network_for_deployment}}"
             hostname: "{{hostvars[item].hostname}}"
-            compute_id: "{{hostvars['localhost'].vc_cluster_for_deployment}}"
-            storage_id: "{{hostvars['localhost'].vc_datastore_for_deployment}}"
+            compute: "{{hostvars['localhost'].vc_cluster_for_deployment}}"
+            storage: "{{hostvars['localhost'].vc_datastore_for_deployment}}"
             default_gateway_addresses:
             - "{{hostvars[item].default_gateway}}"
             management_port_subnets:

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -9,7 +9,7 @@
       vmware.ansible_for_nsxt.nsxt_deploy_ova:
         ovftool_path: "{{ovftool_bin_path}}"
         datacenter: "{{hostvars['localhost'].vcenter_datacenter}}"
-        datastore: "{{hostvars['localhost'].vcenter_datastore}}"
+        datastore: "{{hostvars['localhost'].vc_datastore_for_nsx}}"
         portgroup: "{{hostvars['localhost'].mgmt_portgroup}}"
         cluster: "{{hostvars['localhost'].vcenter_cluster}}"
         vmname: "{{hostvars['localhost'].nsx_manager_assigned_hostname}}"
@@ -217,6 +217,7 @@
         display_name: "{{item.display_name}}"
         description: "NSX {{item.transport_type}} Transport Zone"
         transport_type: "{{item.transport_type}}"
+        is_default: True
         state: "present"
       with_items:
       - "{{transportzones}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -165,7 +165,7 @@
         - hostvars['localhost'].resource_reservation_off == "true"
 
     - name: Deploy additional controller-managers
-      nsxt_controller_manager_auto_deployment:
+      nsxt_manager_auto_deployment:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -6,7 +6,7 @@
     - vars.yml
   tasks:
     - name: deploy NSX Manager OVA
-      nsxt_deploy_ova:
+      vmware.ansible_for_nsxt.nsxt_deploy_ova:
         ovftool_path: "{{ovftool_bin_path}}"
         datacenter: "{{hostvars['localhost'].vcenter_datacenter}}"
         datastore: "{{hostvars['localhost'].vcenter_datastore}}"
@@ -34,7 +34,7 @@
       register: ova_deploy_status
 
     - name: Check manager status
-      nsxt_manager_status:
+      vmware.ansible_for_nsxt.nsxt_manager_status:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -58,7 +58,7 @@
       shell: "last=1; while [ $last -ne 0 ]; do curl -s -o /dev/null -ku '{{hostvars['localhost'].nsx_manager_username}}:{{hostvars['localhost'].nsx_manager_password}}' https://{{hostvars['localhost'].nsx_manager_ip}}/api/v1/trust-management/certificates --connect-timeout 5; last=$?; echo \"waiting for NSX Manager to come up\"; done"
 
     - name: Add license for NSX-T manager if applicable
-      nsxt_licenses:
+      vmware.ansible_for_nsxt.nsxt_licenses:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -107,7 +107,7 @@
       pause: minutes=2
 
     - name: Deploy compute manager
-      nsxt_fabric_compute_managers:
+      vmware.ansible_for_nsxt.nsxt_fabric_compute_managers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -127,7 +127,7 @@
 
     # TODO: change var names
     - name: Deploy compute manager 2
-      nsxt_fabric_compute_managers:
+      vmware.ansible_for_nsxt.nsxt_fabric_compute_managers:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -167,7 +167,7 @@
         - hostvars['localhost'].resource_reservation_off == "true"
 
     - name: Deploy additional controller-managers
-      nsxt_manager_auto_deployment:
+      vmware.ansible_for_nsxt.nsxt_manager_auto_deployment:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -208,7 +208,7 @@
 
       # TODO: does not support tag
     - name: Create Transport Zones
-      nsxt_transport_zones:
+      vmware.ansible_for_nsxt.nsxt_transport_zones:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -222,7 +222,7 @@
       - "{{transportzones}}"
 
     - name: Create uplink profile
-      nsxt_uplink_profiles:
+      vmware.ansible_for_nsxt.nsxt_uplink_profiles:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -238,7 +238,7 @@
 
       # # TODO: support tags
     - name: Create VTEP IP pool
-      nsxt_ip_pools:
+      vmware.ansible_for_nsxt.nsxt_ip_pools:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -267,7 +267,7 @@
         status_code: 200
 
     - name: Add Edge VM as transport node
-      nsxt_transport_nodes:
+      vmware.ansible_for_nsxt.nsxt_transport_nodes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"
@@ -279,6 +279,8 @@
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
+            host_switch_mode: STANDARD
+            host_switch_name: "{{overlay_host_switch}}"
             pnics:
             - device_name: fp-eth0
               uplink_name: "{{uplink_1_name}}"
@@ -287,6 +289,19 @@
               ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{overlay_transport_zone}}"
+          - host_switch_profiles:
+            - name: "{{edge_uplink_prof}}"
+              type: UplinkHostSwitchProfile
+            host_switch_mode: STANDARD
+            host_switch_name: "{{vlan_host_switch}}"
+            pnics:
+            - device_name: fp-eth1
+              uplink_name: "{{uplink_1_name}}"
+            ip_assignment_spec:
+              resource_type: StaticIpPoolSpec
+              ip_pool_name: "{{vtep_ip_pool_name}}"
+            transport_zone_endpoints:
+            - transport_zone_name: "{{vlan_transport_zone}}"
         node_deployment_info:
           resource_type: "EdgeNode"
           display_name: "{{hostvars[item].hostname}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -248,6 +248,19 @@
         state: present
       register: vtep_pool_object
 
+    - name: Apply license
+      uri:
+        url: "https://{{ hostvars['localhost'].nsx_manager_ip }}/api/v1/licenses"
+        method: POST
+        validate_certs: no
+        force_basic_auth: yes
+        user: "{{hostvars['localhost'].nsx_manager_username}}"
+        password: "{{hostvars['localhost'].nsx_manager_password}}"
+        body_format: json
+        body:
+          license_key: "{{license_key}}"
+        status_code: 200
+
     - name: Add Edge VM as transport node
       nsxt_transport_nodes:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -41,16 +41,18 @@
         validate_certs: False
         wait_time: 60
 
-    - name: Wait 2 minutes before accessing NSX Manager API
-      pause: minutes=2
+    - name: Wait for NSX appliances to be status up
+      pause:
+        minutes: "{{hostvars['localhost'].appliance_ready_wait}}"
       when:
         - ova_deploy_status.changed == true
 
     - name: Generate NSX self-signed certificate if it doens't exist
       command: python nsx_t_gen.py --router_config false --generate_cert true
 
-    - name: Wait 2 minutes before accessing NSX Manager API
-      pause: minutes=2
+    - name: Wait for NSX appliances to be status up
+      pause:
+        minutes: "{{hostvars['localhost'].appliance_ready_wait}}"
 
     - name: Wait for Manager API server to be up
       shell: "last=1; while [ $last -ne 0 ]; do curl -s -o /dev/null -ku '{{hostvars['localhost'].nsx_manager_username}}:{{hostvars['localhost'].nsx_manager_password}}' https://{{hostvars['localhost'].nsx_manager_ip}}/api/v1/trust-management/certificates --connect-timeout 5; last=$?; echo \"waiting for NSX Manager to come up\"; done"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -278,6 +278,7 @@
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
+            host_switch_mode: STANDARD
             host_switch_name: "{{overlay_host_switch}}"
             pnics:
             - device_name: fp-eth0
@@ -285,16 +286,18 @@
             ip_assignment_spec:
               resource_type: StaticIpPoolSpec
               ip_pool_name: "{{vtep_ip_pool_name}}"
+            transport_zone_endpoints:
+            - transport_zone_name: "{{overlay_transport_zone}}"
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
+            host_switch_mode: STANDARD
             host_switch_name: "{{vlan_host_switch}}"
             pnics:
             - device_name: fp-eth1
               uplink_name: "{{uplink_1_name}}"
-        transport_zone_endpoints:
-        - transport_zone_name: "{{overlay_transport_zone}}"
-        - transport_zone_name: "{{vlan_transport_zone}}"
+            transport_zone_endpoints:
+            - transport_zone_name: "{{vlan_transport_zone}}"
         node_deployment_info:
           resource_type: "EdgeNode"
           display_name: "{{hostvars[item].hostname}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -288,7 +288,6 @@
               ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{overlay_transport_zone}}"
-              transport_zone_name: "{{vlan_transport_zone}}"
           - host_switch_profiles:
             - name: "{{edge_uplink_prof}}"
               type: UplinkHostSwitchProfile
@@ -302,7 +301,6 @@
               ip_pool_name: "{{vtep_ip_pool_name}}"
             transport_zone_endpoints:
             - transport_zone_name: "{{vlan_transport_zone}}"
-              transport_zone_name: "{{overlay_transport_zone}}"
         node_deployment_info:
           resource_type: "EdgeNode"
           display_name: "{{hostvars[item].hostname}}"

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -165,7 +165,7 @@
         - hostvars['localhost'].resource_reservation_off == "true"
 
     - name: Deploy additional controller-managers
-      nsxt_manager_auto_deployment:
+      nsxt_controller_manager_auto_deployment:
         hostname: "{{hostvars['localhost'].nsx_manager_ip}}"
         username: "{{hostvars['localhost'].nsx_manager_username}}"
         password: "{{hostvars['localhost'].nsx_manager_password}}"

--- a/nsxt_yaml/vars.yml
+++ b/nsxt_yaml/vars.yml
@@ -10,10 +10,8 @@ license_key: "M40VJ-DT34J-381C1-0A222-0NPN7"
 transportzones:
 - display_name: "{{overlay_transport_zone}}"
   transport_type: "OVERLAY"
-  host_switch_name: "{{overlay_host_switch}}" # will create one with this name
 - display_name: "{{vlan_transport_zone}}"
   transport_type: "VLAN"
-  host_switch_name: "{{vlan_host_switch}}"
 
 vtep_ip_pool_name: vtep-ip-pool
 

--- a/nsxt_yaml/vars.yml
+++ b/nsxt_yaml/vars.yml
@@ -5,6 +5,8 @@ overlay_host_switch: "hostswitch-overlay"
 vlan_transport_zone: 'vlan-tz'
 vlan_host_switch: "hostswitch-vlan"
 
+license_key: "M40VJ-DT34J-381C1-0A222-0NPN7"
+
 transportzones:
 - display_name: "{{overlay_transport_zone}}"
   transport_type: "OVERLAY"

--- a/pipelines/nsx-t-install.yml
+++ b/pipelines/nsx-t-install.yml
@@ -32,6 +32,7 @@ nsx_t_install_params: &nsx-t-install-params
   nsx_manager_deployment_ip_prefix_length_int: ((nsx_manager_deployment_ip_prefix_length))
   nsx_manager_ssh_enabled_int: ((nsx_manager_ssh_enabled))
   resource_reservation_off_int: ((resource_reservation_off))
+  appliance_ready_wait_int: ((appliance_ready_wait))
 
   compute_manager_username_int: ((compute_manager_username))
   compute_manager_password_int: ((compute_manager_password))

--- a/sample_parameters/PAS_and_PKS/nsx_pipeline_config.yml
+++ b/sample_parameters/PAS_and_PKS/nsx_pipeline_config.yml
@@ -257,6 +257,7 @@ nsx_t_csr_request_spec: |
     city: SF                     # EDIT
     key_size: 2048               # Valid values: 2048 or 3072
     algorithm: RSA               # Valid values: RSA or DSA
+    days_valid: 3650             # OPTIONAL defaults to 3650
 
 
 nsx_t_lbr_spec: |

--- a/sample_parameters/PAS_and_PKS/nsx_pipeline_config.yml
+++ b/sample_parameters/PAS_and_PKS/nsx_pipeline_config.yml
@@ -36,6 +36,7 @@ vcenter_datacenter: RegionA01
 vcenter_cluster: RegionA01-MGMT
 vcenter_datastore: iscsi
 resource_reservation_off: true
+appliance_ready_wait: 2                  # [OPTIONAL] Minutes to wait for appliance services to be ready after NSX can be pinged
 
 # Compute manager credentials should be the same as above vCenter's if
 # controllers and edges are to be on the same vCenter
@@ -257,7 +258,7 @@ nsx_t_csr_request_spec: |
     city: SF                     # EDIT
     key_size: 2048               # Valid values: 2048 or 3072
     algorithm: RSA               # Valid values: RSA or DSA
-    days_valid: 3650             # OPTIONAL defaults to 3650
+    days_valid: 365              # OPTIONAL defaults to 365
 
 
 nsx_t_lbr_spec: |

--- a/sample_parameters/PAS_only/nsx_pipeline_config.yml
+++ b/sample_parameters/PAS_only/nsx_pipeline_config.yml
@@ -36,6 +36,7 @@ vcenter_datacenter: RegionA01
 vcenter_cluster: RegionA01-MGMT
 vcenter_datastore: iscsi
 resource_reservation_off: true
+appliance_ready_wait: 2                  # [OPTIONAL] Minutes to wait for appliance services to be ready after NSX can be pinged
 
 # Compute manager credentials should be the same as above vCenter's if
 # controllers and edges are to be on the same vCenter
@@ -189,7 +190,7 @@ nsx_t_csr_request_spec: |
     city: SF                     # EDIT
     key_size: 2048               # Valid values: 2048 or 3072
     algorithm: RSA               # Valid values: RSA or DSA
-    days_valid: 3650             # OPTIONAL defaults to 3650
+    days_valid: 365              # OPTIONAL defaults to 365
 
 
 nsx_t_lbr_spec: |

--- a/sample_parameters/PAS_only/nsx_pipeline_config.yml
+++ b/sample_parameters/PAS_only/nsx_pipeline_config.yml
@@ -189,6 +189,7 @@ nsx_t_csr_request_spec: |
     city: SF                     # EDIT
     key_size: 2048               # Valid values: 2048 or 3072
     algorithm: RSA               # Valid values: RSA or DSA
+    days_valid: 3650             # OPTIONAL defaults to 3650
 
 
 nsx_t_lbr_spec: |

--- a/sample_parameters/PKS_only/nsx_pipeline_config.yml
+++ b/sample_parameters/PKS_only/nsx_pipeline_config.yml
@@ -186,6 +186,7 @@ nsx_t_csr_request_spec: |
     city: SF                     # EDIT
     key_size: 2048               # Valid values: 2048 or 3072
     algorithm: RSA               # Valid values: RSA or DSA
+    days_valid: 3650             # OPTIONAL defaults to 3650
 
 
 nsx_t_lbr_spec: |

--- a/sample_parameters/PKS_only/nsx_pipeline_config.yml
+++ b/sample_parameters/PKS_only/nsx_pipeline_config.yml
@@ -36,6 +36,7 @@ vcenter_datacenter: RegionA01
 vcenter_cluster: RegionA01-MGMT
 vcenter_datastore: iscsi
 resource_reservation_off: true
+appliance_ready_wait: 2                  # [OPTIONAL] Minutes to wait for appliance services to be ready after NSX can be pinged
 
 # Compute manager credentials should be the same as above vCenter's if
 # controllers and edges are to be on the same vCenter
@@ -186,7 +187,7 @@ nsx_t_csr_request_spec: |
     city: SF                     # EDIT
     key_size: 2048               # Valid values: 2048 or 3072
     algorithm: RSA               # Valid values: RSA or DSA
-    days_valid: 3650             # OPTIONAL defaults to 3650
+    days_valid: 365              # OPTIONAL defaults to 365
 
 
 nsx_t_lbr_spec: |

--- a/sample_parameters/raw/nsx.yml
+++ b/sample_parameters/raw/nsx.yml
@@ -36,6 +36,7 @@ vcenter_datacenter: RegionA01
 vcenter_cluster: RegionA01-MGMT
 vcenter_datastore: iscsi
 resource_reservation_off: true
+appliance_ready_wait: 2                  # [OPTIONAL] Minutes to wait for appliance services to be ready after NSX can be pinged
 
 # Compute manager credentials should be the same as above vCenter's if
 # controllers and edges are to be on the same vCenter

--- a/sample_parameters/raw/pas.yml
+++ b/sample_parameters/raw/pas.yml
@@ -96,6 +96,7 @@ nsx_t_csr_request_spec: |
     city: SF                     # EDIT
     key_size: 2048               # Valid values: 2048 or 3072
     algorithm: RSA               # Valid values: RSA or DSA
+    days_valid: 3650             # OPTIONAL defaults to 3650
 
 
 nsx_t_lbr_spec: |

--- a/sample_parameters/raw/pks.yml
+++ b/sample_parameters/raw/pks.yml
@@ -93,6 +93,7 @@ nsx_t_csr_request_spec: |
     city: SF                     # EDIT
     key_size: 2048               # Valid values: 2048 or 3072
     algorithm: RSA               # Valid values: RSA or DSA
+    days_valid: 3650             # OPTIONAL defaults to 3650
 
 
 nsx_t_lbr_spec: |

--- a/tasks/add-nsx-t-routers/task.sh
+++ b/tasks/add-nsx-t-routers/task.sh
@@ -28,7 +28,8 @@ fi
 
 create_hosts
 
-cp hosts ${PIPELINE_DIR}/nsxt_yaml/basic_resources.yml ${PIPELINE_DIR}/nsxt_yaml/vars.yml nsxt-ansible/
+cp ${PIPELINE_DIR}/nsxt_yaml/basic_resources.yml ${PIPELINE_DIR}/nsxt_yaml/vars.yml nsxt-ansible/
+cp hosts nsxt-ansible/hosts_file
 cd nsxt-ansible
 
 NO_OF_CONTROLLERS=$(curl -k -u "admin:$nsx_manager_password_int" \
@@ -43,7 +44,7 @@ fi
 # when obtaining thumbprints
 echo "[defaults]" > ansible.cfg
 echo "host_key_checking = false" >> ansible.cfg
-ansible-playbook $DEBUG -i hosts basic_resources.yml
+ansible-playbook $DEBUG -i hosts_file basic_resources.yml
 STATUS=$?
 
 exit $STATUS

--- a/tasks/add-nsx-t-routers/task.yml
+++ b/tasks/add-nsx-t-routers/task.yml
@@ -5,7 +5,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: dyanngg/nsx-t-gen-worker
+    repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
     tag: py3
 
 inputs:

--- a/tasks/config-nsx-t-extras/nsx_t_gen.py
+++ b/tasks/config-nsx-t-extras/nsx_t_gen.py
@@ -615,7 +615,7 @@ def generate_self_signed_cert(common_name, csr_request):
     resp = client.post(api_endpoint, payload)
     csr_id = resp.json()['id']
 
-    days_valid = csr_request.get('days_valid', '3650')
+    days_valid = csr_request.get('days_valid', '365')
     self_sign_cert_api_endpint = TRUST_MGMT_SELF_SIGN_CERT
     self_sign_cert_url = ('%s%s?action=self_sign&&days_valid=%s' %
                           (self_sign_cert_api_endpint, csr_id, days_valid))

--- a/tasks/config-nsx-t-extras/nsx_t_gen.py
+++ b/tasks/config-nsx-t-extras/nsx_t_gen.py
@@ -615,8 +615,10 @@ def generate_self_signed_cert(common_name, csr_request):
     resp = client.post(api_endpoint, payload)
     csr_id = resp.json()['id']
 
+    days_valid = csr_request.get('days_valid', '3650')
     self_sign_cert_api_endpint = TRUST_MGMT_SELF_SIGN_CERT
-    self_sign_cert_url = '%s%s%s' % (self_sign_cert_api_endpint, csr_id, '?action=self_sign')
+    self_sign_cert_url = ('%s%s?action=self_sign&&days_valid=%s' %
+                          (self_sign_cert_api_endpint, csr_id, days_valid))
     self_sign_csr_response = client.post(self_sign_cert_url, '').json()
     print('CSR Request posted with response %s' % self_sign_csr_response)
     return self_sign_csr_response['id']

--- a/tasks/config-nsx-t-extras/task.yml
+++ b/tasks/config-nsx-t-extras/task.yml
@@ -5,7 +5,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: dyanngg/nsx-t-gen-worker
+    repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
     tag: py3
 
 params:

--- a/tasks/install-nsx-t/modify_options.py
+++ b/tasks/install-nsx-t/modify_options.py
@@ -10,7 +10,7 @@ DATA_NETWORKS = "data_networks:"
 MANAGEMENT_NETWORK = "management_network: \"{{hostvars[item]"
 COMPUTE = "compute: \"{{hostvars[item].vc_cluster_for_edge"
 STORAGE = "storage: \"{{hostvars[item].vc_datastore_for_edge"
-
+NODE_SETTINGS = "node_settings"
 
 def add_new_line_if_absent(line):
     if line.endswith('\n'):
@@ -38,16 +38,14 @@ def add_dns_server_option():
                     dns_line = ' ' * leading_spaces + ("dns_server: %s\n"
                                                        % dns_servers_spec.split(',')[0])
                     line = line.replace(line, dns_line)
-                elif PREFIX_LENGTH in line:
-                    leading_spaces = len(line) - len(line.lstrip()) - 2
+                elif NODE_SETTINGS in line:
+                    leading_spaces = len(line) - len(line.lstrip()) + 2
                     dns_line = ' ' * leading_spaces
-                    if ',' not in dns_servers_spec:
-                        dns_line += "dns_servers: [\"{{hostvars['localhost'].dns_server}}\"]"
-                    else:
-                        dns_servers = [s.strip() for s in dns_servers_spec.split(',')]
-                        dns_line += "dns_servers:"
-                        for server in dns_servers:
-                            dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
+
+                    dns_servers = [s.strip() for s in dns_servers_spec.split(',')]
+                    dns_line += "dns_servers:"
+                    for server in dns_servers:
+                        dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
                     line = line.replace(line, line + dns_line)
                 new_file.write(add_new_line_if_absent(line))
     replace_file(abs_path)

--- a/tasks/install-nsx-t/modify_options.py
+++ b/tasks/install-nsx-t/modify_options.py
@@ -1,7 +1,5 @@
-from tempfile import mkstemp
-from shutil import move, copymode
+import fileinput
 import os
-from os import fdopen, remove
 
 TOPOLOGY_FILE = "basic_topology.yml"
 DNS_SERVER = "hostvars['localhost'].dns_server"
@@ -12,69 +10,49 @@ COMPUTE = "compute: \"{{hostvars[item].vc_cluster_for_edge"
 STORAGE = "storage: \"{{hostvars[item].vc_datastore_for_edge"
 
 
-def add_new_line_if_absent(line):
-    if line.endswith('\n'):
-        return line
-    return line + '\n'
-
-
-def replace_file(tmp_file_path):
-    # Copy the file permissions from the old file to the new file
-    copymode(TOPOLOGY_FILE, tmp_file_path)
-    # Remove original file
-    remove(TOPOLOGY_FILE)
-    # Move new file
-    move(tmp_file_path, "basic_topology.yml")
-
-
 def add_dns_server_option():
     dns_servers_spec = os.getenv('dns_server_int')
-    fh, abs_path = mkstemp()
-    with fdopen(fh, 'w') as new_file:
-        with open(TOPOLOGY_FILE) as old_file:
-            for line in old_file:
-                if DNS_SERVER in line and ',' in dns_servers_spec:
-                    leading_spaces = len(line) - len(line.lstrip())
-                    dns_line = ' ' * leading_spaces + ("dns_server: %s\n"
-                                                       % dns_servers_spec.split(',')[0])
-                    line = line.replace(line, dns_line)
-                elif PREFIX_LENGTH in line:
-                    leading_spaces = len(line) - len(line.lstrip()) - 2
-                    dns_line = ' ' * leading_spaces
-                    if ',' not in dns_servers_spec:
-                        dns_line += "dns_servers: [\"{{hostvars['localhost'].dns_server}}\"]"
-                    else:
-                        dns_servers = [s.strip() for s in dns_servers_spec.split(',')]
-                        dns_line += "dns_servers:"
-                        for server in dns_servers:
-                            dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
-                    line = line.replace(line, line + dns_line)
-                new_file.write(add_new_line_if_absent(line))
-    replace_file(abs_path)
+    for line in fileinput.FileInput(TOPOLOGY_FILE, inplace=1):
+        if DNS_SERVER in line and ',' in dns_servers_spec:
+            leading_spaces = len(line) - len(line.lstrip())
+            dns_line = ' ' * leading_spaces + "dns_server: %s\n" % dns_servers_spec.split(',')[0]
+            line = line.replace(line, dns_line)
+        elif PREFIX_LENGTH in line:
+            leading_spaces = len(line) - len(line.lstrip()) - 2
+            dns_line = ' ' * leading_spaces
+            if ',' not in dns_servers_spec:
+                dns_line += "dns_servers: [\"{{hostvars['localhost'].dns_server}}\"]"
+            else:
+                dns_servers = [s.strip() for s in dns_servers_spec.split(',')]
+                dns_line += "dns_servers:"
+                for server in dns_servers:
+                    dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
+            line = line.replace(line, line + dns_line + '\n')
+        print line,
+        # For Python3 use following line instead
+        # print(line, end='')
 
 
 def add_ids_in_param_if_necessary():
 
     def add_id_to_param(matched_line):
-        leading_spaces = len(line) - len(line.lstrip())
-        items = matched_line.lstrip().split(' ')
-        newline = ' ' * leading_spaces + items[0][:-1] + "_id: " + items[1]
+        items = matched_line.split(' ')
+        newline = items[0][:-1] + "_id: " + items[1]
         return newline
 
     ansible_branch = os.getenv('nsxt_ansible_branch_int').strip()
     if ansible_branch and ansible_branch == 'master':
-        fh, abs_path = mkstemp()
-        with fdopen(fh, 'w') as new_file:
-            with open(TOPOLOGY_FILE) as old_file:
-                for line in old_file:
-                    if "data_networks:" in line:
-                        leading_spaces = len(line) - len(line.lstrip())
-                        line_with_id = ' ' * leading_spaces + "data_network_ids:"
-                        line = line.replace(line, line_with_id)
-                    elif MANAGEMENT_NETWORK in line or COMPUTE in line or STORAGE in line:
-                        line = line.replace(line,  add_id_to_param(line))
-                    new_file.write(add_new_line_if_absent(line))
-        replace_file(abs_path)
+        for line in fileinput.FileInput(TOPOLOGY_FILE, inplace=1):
+            if "data_networks:" in line:
+                leading_spaces = len(line) - len(line.lstrip())
+                line_with_id = ' ' * leading_spaces + "data_network_ids:"
+                line = line.replace(line, line_with_id)
+            elif MANAGEMENT_NETWORK in line or COMPUTE in line or STORAGE in line:
+                line_with_id = add_id_to_param(line)
+                line = line.replace(line, line_with_id)
+            print line,
+            # For Python3 use following line instead
+            # print(line, end='')
 
 
 if __name__ == "__main__":

--- a/tasks/install-nsx-t/modify_options.py
+++ b/tasks/install-nsx-t/modify_options.py
@@ -1,5 +1,7 @@
-import fileinput
+from tempfile import mkstemp
+from shutil import move, copymode
 import os
+from os import fdopen, remove
 
 TOPOLOGY_FILE = "basic_topology.yml"
 DNS_SERVER = "hostvars['localhost'].dns_server"
@@ -10,49 +12,69 @@ COMPUTE = "compute: \"{{hostvars[item].vc_cluster_for_edge"
 STORAGE = "storage: \"{{hostvars[item].vc_datastore_for_edge"
 
 
+def add_new_line_if_absent(line):
+    if line.endswith('\n'):
+        return line
+    return line + '\n'
+
+
+def replace_file(tmp_file_path):
+    # Copy the file permissions from the old file to the new file
+    copymode(TOPOLOGY_FILE, tmp_file_path)
+    # Remove original file
+    remove(TOPOLOGY_FILE)
+    # Move new file
+    move(tmp_file_path, "basic_topology.yml")
+
+
 def add_dns_server_option():
     dns_servers_spec = os.getenv('dns_server_int')
-    for line in fileinput.FileInput(TOPOLOGY_FILE, inplace=1):
-        if DNS_SERVER in line and ',' in dns_servers_spec:
-            leading_spaces = len(line) - len(line.lstrip())
-            dns_line = ' ' * leading_spaces + "dns_server: %s\n" % dns_servers_spec.split(',')[0]
-            line = line.replace(line, dns_line)
-        elif PREFIX_LENGTH in line:
-            leading_spaces = len(line) - len(line.lstrip()) - 2
-            dns_line = ' ' * leading_spaces
-            if ',' not in dns_servers_spec:
-                dns_line += "dns_servers: [\"{{hostvars['localhost'].dns_server}}\"]"
-            else:
-                dns_servers = [s.strip() for s in dns_servers_spec.split(',')]
-                dns_line += "dns_servers:"
-                for server in dns_servers:
-                    dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
-            line = line.replace(line, line + dns_line + '\n')
-        print line,
-        # For Python3 use following line instead
-        # print(line, end='')
+    fh, abs_path = mkstemp()
+    with fdopen(fh, 'w') as new_file:
+        with open(TOPOLOGY_FILE) as old_file:
+            for line in old_file:
+                if DNS_SERVER in line and ',' in dns_servers_spec:
+                    leading_spaces = len(line) - len(line.lstrip())
+                    dns_line = ' ' * leading_spaces + ("dns_server: %s\n"
+                                                       % dns_servers_spec.split(',')[0])
+                    line = line.replace(line, dns_line)
+                elif PREFIX_LENGTH in line:
+                    leading_spaces = len(line) - len(line.lstrip()) - 2
+                    dns_line = ' ' * leading_spaces
+                    if ',' not in dns_servers_spec:
+                        dns_line += "dns_servers: [\"{{hostvars['localhost'].dns_server}}\"]"
+                    else:
+                        dns_servers = [s.strip() for s in dns_servers_spec.split(',')]
+                        dns_line += "dns_servers:"
+                        for server in dns_servers:
+                            dns_line += '\n' + ' ' * leading_spaces + "- %s" % server
+                    line = line.replace(line, line + dns_line)
+                new_file.write(add_new_line_if_absent(line))
+    replace_file(abs_path)
 
 
 def add_ids_in_param_if_necessary():
 
     def add_id_to_param(matched_line):
-        items = matched_line.split(' ')
-        newline = items[0][:-1] + "_id: " + items[1]
+        leading_spaces = len(line) - len(line.lstrip())
+        items = matched_line.lstrip().split(' ')
+        newline = ' ' * leading_spaces + items[0][:-1] + "_id: " + items[1]
         return newline
 
     ansible_branch = os.getenv('nsxt_ansible_branch_int').strip()
     if ansible_branch and ansible_branch == 'master':
-        for line in fileinput.FileInput(TOPOLOGY_FILE, inplace=1):
-            if "data_networks:" in line:
-                leading_spaces = len(line) - len(line.lstrip())
-                line_with_id = ' ' * leading_spaces + "data_network_ids:"
-                line = line.replace(line, line_with_id)
-            elif MANAGEMENT_NETWORK in line or COMPUTE in line or STORAGE in line:
-                line_with_id = add_id_to_param(line)
-                line = line.replace(line, line_with_id)
-            print line,
-            # For Python3 use following line instead
-            # print(line, end='')
+        fh, abs_path = mkstemp()
+        with fdopen(fh, 'w') as new_file:
+            with open(TOPOLOGY_FILE) as old_file:
+                for line in old_file:
+                    if "data_networks:" in line:
+                        leading_spaces = len(line) - len(line.lstrip())
+                        line_with_id = ' ' * leading_spaces + "data_network_ids:"
+                        line = line.replace(line, line_with_id)
+                    elif MANAGEMENT_NETWORK in line or COMPUTE in line or STORAGE in line:
+                        line = line.replace(line,  add_id_to_param(line))
+                    new_file.write(add_new_line_if_absent(line))
+        replace_file(abs_path)
 
 
 if __name__ == "__main__":

--- a/tasks/install-nsx-t/nsxt-ansible-requirements.yml
+++ b/tasks/install-nsx-t/nsxt-ansible-requirements.yml
@@ -1,0 +1,6 @@
+---
+# requirements.yml
+collections:
+  - name: ansible-for-nsxt
+    type: git
+    source: https://github.com/vmware/ansible-for-nsxt.git,v3.2.0

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -75,6 +75,9 @@ create_hosts
 cp ${PIPELINE_DIR}/tasks/install-nsx-t/get_mo_ref_id.py ./
 python get_mo_ref_id.py --host $vcenter_ip_int --user $vcenter_username_int --password $vcenter_password_int
 
+echo "echo hosts.out "
+cat hosts.out
+
 cp hosts.out ${PIPELINE_DIR}/nsxt_yaml/basic_topology.yml ${PIPELINE_DIR}/nsxt_yaml/vars.yml nsxt-ansible/
 cd nsxt-ansible
 echo "cd nsxt-ansible"

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -66,12 +66,20 @@ if [ "$enable_ansible_debug_int" == "true" ]; then
   DEBUG="-vvv"
 fi
 
+echo "Install Ansible NSXT v3.2.0 Galaxy collection"
+#ansible-galaxy collection install git+https://github.com/vmware/ansible-for-nsxt.git,v3.2.0
+cp ${PIPELINE_DIR}/tasks/install-nsx-t/nsxt-ansible-requirements.yml ./
+ansible-galaxy collection install -r ./nsxt-ansible-requirements.yml
+
 create_hosts
 cp ${PIPELINE_DIR}/tasks/install-nsx-t/get_mo_ref_id.py ./
 python get_mo_ref_id.py --host $vcenter_ip_int --user $vcenter_username_int --password $vcenter_password_int
 
 cp hosts.out ${PIPELINE_DIR}/nsxt_yaml/basic_topology.yml ${PIPELINE_DIR}/nsxt_yaml/vars.yml nsxt-ansible/
 cd nsxt-ansible
+echo "cd nsxt-ansible"
+ls
+
 cp ${PIPELINE_DIR}/tasks/install-nsx-t/modify_options.py ./
 
 if [[ "$unified_appliance_int" == "true" ]]; then

--- a/tasks/install-nsx-t/task.yml
+++ b/tasks/install-nsx-t/task.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
-    tag: py3
+    tag: ubuntu18
 
 inputs:
   - name: nsx-t-gen-pipeline

--- a/tasks/install-nsx-t/task.yml
+++ b/tasks/install-nsx-t/task.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
-    tag: ubuntu18
+    tag: ubuntu18-v1
 
 inputs:
   - name: nsx-t-gen-pipeline

--- a/tasks/install-nsx-t/task.yml
+++ b/tasks/install-nsx-t/task.yml
@@ -5,7 +5,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: dyanngg/nsx-t-gen-worker
+    repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
     tag: py3
 
 inputs:

--- a/tasks/install-nsx-t/turn_off_reservation.py
+++ b/tasks/install-nsx-t/turn_off_reservation.py
@@ -10,11 +10,7 @@ from pyVim.connect import SmartConnectNoSSL, Disconnect
 
 import argparse
 import atexit
-import getpass
-import json
-import sys
 
-from tools import cli
 from tools import tasks
 
 import pdb

--- a/tasks/uninstall-nsx-t/task.yml
+++ b/tasks/uninstall-nsx-t/task.yml
@@ -5,7 +5,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: dyanngg/nsx-t-gen-worker
+    repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
     tag: py3
   
 # params:

--- a/tasks/uninstall-nsx-t/task.yml
+++ b/tasks/uninstall-nsx-t/task.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
-    tag: ubuntu18
+    tag: ubuntu18-v1
 
 # params:
 #   VCENTER_HOST:

--- a/tasks/uninstall-nsx-t/task.yml
+++ b/tasks/uninstall-nsx-t/task.yml
@@ -6,17 +6,17 @@ image_resource:
   type: docker-image
   source:
     repository: projects.registry.vmware.com/nsxt_gen_pipeline/nsx-t-gen-worker
-    tag: py3
-  
+    tag: ubuntu18
+
 # params:
 #   VCENTER_HOST:
 #   VCENTER_USR:
 #   VCENTER_PWD:
 
-    
+
 inputs:
   - name: nsx-t-gen-pipeline
-  
+
 run:
   path: nsx-t-gen-pipeline/tasks/uninstall-nsx-t/task.sh
 


### PR DESCRIPTION
In the beginging, the deployed cluster1 datastore naming convention is fixed as:
            #{'concourse_dc1': {'cluster': {'cluster1': 'domain-c9'},
            #           'datastore': {'datastore': 'datastore-13',
            #                                 'datastore (1)': 'datastore-17',
            #                                 'vsanDatastore': 'datastore-49' }}}
However, the datastore naming is changed with dynamic naming format that is changed according
to ESXi host ip name like:
            #{'concourse_dc1': {'cluster': {'cluster1': 'domain-c27'},
            #           'datastore': {'datastore-10.221.121.47': 'datastore-32',
            #                                'datastore-10.221.121.48': 'datastore-36',
            #                                'vsanDatastore': 'datastore-49'},}}

This patch is to support deployed cluster1 datastore naming convention change to
rebuild datastore name in mapping from dynamic datastore name input and output a fixed
datastore name mapping, one for nsx_datastore and one for edge_datastore.