### PR TITLE
Fix datastore name change of deployed cluster1 in VCenter

### DIFF
--- a/functions/create_hosts.sh
+++ b/functions/create_hosts.sh
@@ -144,6 +144,7 @@ mgmt_portgroup="$mgmt_portgroup_int"
 
 vc_datacenter_for_deployment="$vcenter_datacenter_int"
 vc_cluster_for_deployment="$vcenter_cluster_int"
+vc_datastore_for_nsx="$vcenter_datastore_int"
 vc_datastore_for_deployment="$vcenter_datastore_int"
 vc_management_network_for_deployment="$mgmt_portgroup_int"
 

--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -9,7 +9,7 @@
       vmware.ansible_for_nsxt.nsxt_deploy_ova:
         ovftool_path: "{{ovftool_bin_path}}"
         datacenter: "{{hostvars['localhost'].vcenter_datacenter}}"
-        datastore: "{{hostvars['localhost'].vcenter_datastore}}"
+        datastore: "{{hostvars['localhost'].vc_datastore_for_nsx}}"
         portgroup: "{{hostvars['localhost'].mgmt_portgroup}}"
         cluster: "{{hostvars['localhost'].vcenter_cluster}}"
         vmname: "{{hostvars['localhost'].nsx_manager_assigned_hostname}}"
@@ -217,6 +217,7 @@
         display_name: "{{item.display_name}}"
         description: "NSX {{item.transport_type}} Transport Zone"
         transport_type: "{{item.transport_type}}"
+        is_default: True
         state: "present"
       with_items:
       - "{{transportzones}}"

--- a/tasks/install-nsx-t/task.sh
+++ b/tasks/install-nsx-t/task.sh
@@ -75,6 +75,9 @@ create_hosts
 cp ${PIPELINE_DIR}/tasks/install-nsx-t/get_mo_ref_id.py ./
 python get_mo_ref_id.py --host $vcenter_ip_int --user $vcenter_username_int --password $vcenter_password_int
 
+echo "echo hosts.out "
+cat hosts.out
+
 cp hosts.out ${PIPELINE_DIR}/nsxt_yaml/basic_topology.yml ${PIPELINE_DIR}/nsxt_yaml/vars.yml nsxt-ansible/
 cd nsxt-ansible
 echo "cd nsxt-ansible"


### PR DESCRIPTION
In the beginging, the deployed cluster1 datastore naming convention is fixed as:
    #{'concourse_dc1': {'cluster': {'cluster1': 'domain-c9'},
    #                   'datastore': {'datastore': 'datastore-13',
    #                                 'datastore (1)': 'datastore-17',
    #                                 'vsanDatastore': 'datastore-49' }}}
However, the datastore naming is changed with dynamic naming format that is changed according
to ESXi host ip name like:
    #{'concourse_dc1': {'cluster': {'cluster1': 'domain-c27'},
    #                   'datastore': {'datastore-10.221.121.47': 'datastore-32',
    #                                 'datastore-10.221.121.48': 'datastore-36',
    #                                 'vsanDatastore': 'datastore-49'},}}

This patch is to support deployed cluster1 datastore naming convention change to rebuild datastore name in mapping from dynamic datastore name input and output a fixed datastore name mapping, one for nsx_datastore and one for edge_datastore.

Signed-off-by: Yun Deng<dengyu@vmware.com>