### PR TITLE
remove mtu for uplink profile

### DIFF
--- a/nsxt_yaml/basic_topology.yml
+++ b/nsxt_yaml/basic_topology.yml
@@ -230,7 +230,6 @@
         validate_certs: False
         resource_type: UplinkHostSwitchProfile
         display_name: "{{item.display_name}}"
-        mtu: 1600
         teaming: "{{item.teaming}}"
         transport_vlan: "{{item.transport_vlan}}"
         state: "present"


### PR DESCRIPTION
From nsx 4.1.1, the default vds uplink mtu size is 1700. So, removing mtu setting when creating uplink profile so that the uplink profile will use default mtu size from vds.